### PR TITLE
fix: nat const handling, is_valid_ind_app univ's

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "nanoda_lib"
-version = "0.4.1-beta"
+version = "0.4.2-beta"
 dependencies = [
  "indexmap",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "nanoda_lib"
-version = "0.4.1-beta"
+version = "0.4.2-beta"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/ammkrn/nanoda_lib"

--- a/src/debug_printer.rs
+++ b/src/debug_printer.rs
@@ -168,7 +168,7 @@ impl<'x, 't, 'p> std::fmt::Debug for DebugPrinter<'x, 't, 'p, ExprPtr<'t>> {
             Proj { idx, structure, .. } => {
                 write!(f, "%({:?}).{}", self.ctx.debug_print(structure), idx)
             }
-            NatLit { ptr, .. } => write!(f, "NLit({})", self.ctx.read_bignum(ptr)),
+            NatLit { ptr, .. } => write!(f, "NLit({})", self.ctx.read_bignum(ptr).unwrap()),
             StringLit { ptr, .. } => write!(f, "SLit({})", self.ctx.read_string(ptr)),
         }
     }
@@ -186,7 +186,7 @@ impl<'x, 't, 'p> std::fmt::Debug for DebugPrinter<'x, 't, 'p, crate::util::Strin
 }
 impl<'x, 't, 'p> std::fmt::Debug for DebugPrinter<'x, 't, 'p, crate::util::BigUintPtr<'t>> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self.ctx.read_bignum(self.elem_to_print))
+        write!(f, "{:?}", self.ctx.read_bignum(self.elem_to_print).unwrap())
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,8 @@ fn use_config(config_path: &Path) -> Result<Option<String>, Box<dyn Error>> {
                 pp_errs
             )))
         }
+    } else if skipped_axioms.is_empty() {
+        Ok(None)
     } else {
         Ok(Some(format!("Skipped exported but unpermitted axioms {:?}", skipped_axioms)))
     }

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -758,7 +758,7 @@ impl<'x, 't, 'p> PrettyPrinter<'x, 't, 'p> {
                         .concat(DocPtr::from((idx + 1).to_string()))
                         .as_unparenable()
                 }
-                NatLit { ptr, .. } => DocPtr::from(self.ctx.read_bignum(ptr).to_string()).as_unparenable(),
+                NatLit { ptr, .. } => DocPtr::from(self.ctx.read_bignum(ptr).unwrap().to_string()).as_unparenable(),
                 StringLit { ptr, .. } => {
                     DocPtr::from("\"")
                     .concat(DocPtr::from(self.ctx.read_string(ptr).as_ref()))

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -64,8 +64,8 @@ impl<'t, 'p: 't> TcCtx<'t, 'p> {
     #[cfg(test)]
     #[allow(dead_code)]
     pub(crate) fn mk_succ_app(&mut self, n: usize) -> ExprPtr<'t> {
-        let mut out = self.c_nat_zero();
-        let succ = self.c_nat_succ();
+        let mut out = self.c_nat_zero().unwrap();
+        let succ = self.c_nat_succ().unwrap();
         for _ in 0..n {
             out = self.mk_app(succ, out);
         }


### PR DESCRIPTION
More gentle handling/rejection for when the native extensions are used and when certain constants are/aren't defined.

Adds a check for the applied universe levels in is_valid_ind_app