### PR TITLE
fix: remove and disallow truncating casts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "nanoda_lib"
-version = "0.4.6-beta"
+version = "0.4.7-beta"
 dependencies = [
  "indexmap",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "nanoda_lib"
-version = "0.4.6-beta"
+version = "0.4.7-beta"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/ammkrn/nanoda_lib"

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -282,14 +282,12 @@ impl<'t, 'p: 't> TcCtx<'t, 'p> {
             *cached
         } else {
             let calcd = match self.read_expr(e) {
-                Local { .. } => locals
+                Local { .. } => 
+                    locals
                     .iter()
                     .rev()
                     .position(|x| *x == e)
-                    .map(|pos| {
-                        let idx = u16::try_from(pos).unwrap() + offset;
-                        self.mk_var(idx)
-                    })
+                    .map(|pos| self.mk_var(u16::try_from(pos).unwrap() + offset))
                     .unwrap_or(e),
                 App { fun, arg, .. } => {
                     let fun = self.abstr_aux(fun, locals, offset);

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -282,8 +282,15 @@ impl<'t, 'p: 't> TcCtx<'t, 'p> {
             *cached
         } else {
             let calcd = match self.read_expr(e) {
-                Local { .. } =>
-                    locals.iter().rev().position(|x| *x == e).map(|pos| self.mk_var(pos as u16 + offset)).unwrap_or(e),
+                Local { .. } => locals
+                    .iter()
+                    .rev()
+                    .position(|x| *x == e)
+                    .map(|pos| {
+                        let idx = u16::try_from(pos).unwrap() + offset;
+                        self.mk_var(idx)
+                    })
+                    .unwrap_or(e),
                 App { fun, arg, .. } => {
                     let fun = self.abstr_aux(fun, locals, offset);
                     let arg = self.abstr_aux(arg, locals, offset);

--- a/src/inductive.rs
+++ b/src/inductive.rs
@@ -966,7 +966,8 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
     fn mk_motive_dep(&mut self, st: &InductiveCheckState<'t>, major: ExprPtr<'t>, ind_type_idx: u64) -> ExprPtr<'t> {
         let elim_sort = self.ctx.mk_sort(st.elim_level.unwrap());
         let w_major = self.ctx.abstr_pi(major, elim_sort);
-        let motive_type = self.ctx.abstr_pi_telescope(&st.local_indices[ind_type_idx as usize], w_major);
+        let local_idx = usize::try_from(ind_type_idx).unwrap();
+        let motive_type = self.ctx.abstr_pi_telescope(&st.local_indices[local_idx], w_major);
         let motive_name_base = self.ctx.str1("motive");
         let motive_name = if st.all_inductives_incl_specialized.len() > 1 {
             // Lean uses 1-based indexing for these, so we try to match for the pretty printer output.

--- a/src/inductive.rs
+++ b/src/inductive.rs
@@ -966,8 +966,7 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
     fn mk_motive_dep(&mut self, st: &InductiveCheckState<'t>, major: ExprPtr<'t>, ind_type_idx: u64) -> ExprPtr<'t> {
         let elim_sort = self.ctx.mk_sort(st.elim_level.unwrap());
         let w_major = self.ctx.abstr_pi(major, elim_sort);
-        let local_idx = usize::try_from(ind_type_idx).unwrap();
-        let motive_type = self.ctx.abstr_pi_telescope(&st.local_indices[local_idx], w_major);
+        let motive_type = self.ctx.abstr_pi_telescope(&st.local_indices[usize::try_from(ind_type_idx).unwrap()], w_major);
         let motive_name_base = self.ctx.str1("motive");
         let motive_name = if st.all_inductives_incl_specialized.len() > 1 {
             // Lean uses 1-based indexing for these, so we try to match for the pretty printer output.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 //! Doc comment example
 //! ```
 #![allow(clippy::too_many_arguments)]
+#![deny(clippy::cast_possible_truncation)]
 
 pub mod debug_printer;
 pub mod env;

--- a/src/tc.rs
+++ b/src/tc.rs
@@ -861,7 +861,8 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
                 x = body1;
                 y = body2;
             } else {
-                self.ctx.dbj_level_counter -= (locals.len() as u16);
+                let local_levels = u16::try_from(locals.len()).unwrap();
+                self.ctx.dbj_level_counter -= local_levels;
                 return Some(false)
             }
         }
@@ -869,7 +870,8 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
         let x = self.ctx.inst(x, locals.as_slice());
         let y = self.ctx.inst(y, locals.as_slice());
         let r = self.def_eq(x, y);
-        self.ctx.dbj_level_counter -= (locals.len() as u16);
+        let local_levels = u16::try_from(locals.len()).unwrap();
+        self.ctx.dbj_level_counter -= local_levels;
         Some(r)
     }
 

--- a/src/tc.rs
+++ b/src/tc.rs
@@ -861,8 +861,7 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
                 x = body1;
                 y = body2;
             } else {
-                let local_levels = u16::try_from(locals.len()).unwrap();
-                self.ctx.dbj_level_counter -= local_levels;
+                self.ctx.dbj_level_counter -= u16::try_from(locals.len()).unwrap();
                 return Some(false)
             }
         }
@@ -870,8 +869,7 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
         let x = self.ctx.inst(x, locals.as_slice());
         let y = self.ctx.inst(y, locals.as_slice());
         let r = self.def_eq(x, y);
-        let local_levels = u16::try_from(locals.len()).unwrap();
-        self.ctx.dbj_level_counter -= local_levels;
+        self.ctx.dbj_level_counter -= u16::try_from(locals.len()).unwrap();
         Some(r)
     }
 


### PR DESCRIPTION
This replaces a few raw `as` casts, which could introduce silent integers truncation.
It also adds a `clippy` deny directive to catch similar cases in the future.