### PR TITLE
Optimize hash-consing and parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,34 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "cfg-if"
@@ -21,14 +45,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "halfbrown"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8588661a8607108a5ca69cab034063441a0413a0b041c13618a7dd348021ef6f"
+dependencies = [
+ "hashbrown 0.14.5",
+ "serde",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -44,7 +99,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -52,6 +107,16 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -78,6 +143,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "simd-json",
 ]
 
 [[package]]
@@ -110,6 +176,12 @@ checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "ppv-lite86"
@@ -166,10 +238,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -227,6 +325,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-json"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2bcf6c6e164e81bc7a5d49fc6988b3d515d9e8c07457d7b74ffb9324b9cd40"
+dependencies = [
+ "getrandom",
+ "halfbrown",
+ "ref-cast",
+ "serde",
+ "serde_json",
+ "simdutf8",
+ "value-trait",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "syn"
 version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,7 +363,90 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "value-trait"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9170e001f458781e92711d2ad666110f153e4e50bfd5cbd02db6547625714187"
+dependencies = [
+ "float-cmp",
+ "halfbrown",
+ "itoa",
+ "ryu",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "getrandom"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,6 +97,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "indexmap"
@@ -134,6 +145,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 name = "nanoda_lib"
 version = "0.4.8-beta"
 dependencies = [
+ "hashbrown 0.16.1",
  "indexmap",
  "num-bigint",
  "num-integer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ num-integer = "0.1.46"
 num-traits = "0.2.17"
 semver = "1.0.27"
 serde_json = "1.0.111"
+simd-json = { version = "0.14", features = ["serde_impl"] }
 serde = { version = "1.0.228", features = ["derive"] }
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ rand = "0.8.5"
 num-bigint = { version = "0.4.4", features = ["rand", "serde"] }
 
 [dependencies]
+hashbrown = "0.16"
 indexmap = "2.13.0"
 rustc-hash = "1.1.0"
 num-bigint = { version = "0.4.4", features = ["serde"] }
@@ -35,4 +36,3 @@ serde = { version = "1.0.228", features = ["derive"] }
 [[bin]]
 name = "nanoda_bin"
 path = "src/main.rs"
-bench = false

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -39,8 +39,8 @@ pub enum Expr<'a> {
         /// `q` will have idx 1.
         idx: usize,
         structure: ExprPtr<'a>,
-        num_loose_bvars: u16,
-        has_fvars: bool,
+        /// Packed metadata: bits 0-12 = num_loose_bvars, bit 13 = has_fvars, bits 14-15 unused.
+        meta: u16,
     },
     /// A bound variable represented by a deBruijn index.
     Var {
@@ -60,26 +60,24 @@ pub enum Expr<'a> {
         hash: u64,
         fun: ExprPtr<'a>,
         arg: ExprPtr<'a>,
-        num_loose_bvars: u16,
-        has_fvars: bool,
+        /// Packed metadata: bits 0-12 = num_loose_bvars, bit 13 = has_fvars, bits 14-15 unused.
+        meta: u16,
     },
     Pi {
         hash: u64,
         binder_name: NamePtr<'a>,
-        binder_style: BinderStyle,
         binder_type: ExprPtr<'a>,
         body: ExprPtr<'a>,
-        num_loose_bvars: u16,
-        has_fvars: bool,
+        /// Packed metadata: bits 0-12 = num_loose_bvars, bit 13 = has_fvars, bits 14-15 = binder_style.
+        meta: u16,
     },
     Lambda {
         hash: u64,
         binder_name: NamePtr<'a>,
-        binder_style: BinderStyle,
         binder_type: ExprPtr<'a>,
         body: ExprPtr<'a>,
-        num_loose_bvars: u16,
-        has_fvars: bool,
+        /// Packed metadata: bits 0-12 = num_loose_bvars, bit 13 = has_fvars, bits 14-15 = binder_style.
+        meta: u16,
     },
     Let {
         hash: u64,
@@ -87,8 +85,8 @@ pub enum Expr<'a> {
         binder_type: ExprPtr<'a>,
         val: ExprPtr<'a>,
         body: ExprPtr<'a>,
-        num_loose_bvars: u16,
-        has_fvars: bool,
+        /// Packed metadata: bits 0-12 = num_loose_bvars, bit 13 = has_fvars, bits 14-15 unused.
+        meta: u16,
         nondep: bool
     },
     /// A free variable with binder information, and either a unique
@@ -149,6 +147,56 @@ pub enum BinderStyle {
     InstanceImplicit,
 }
 
+impl From<BinderStyle> for u16 {
+    fn from(bs: BinderStyle) -> u16 {
+        match bs {
+            BinderStyle::Default => 0,
+            BinderStyle::Implicit => 1,
+            BinderStyle::StrictImplicit => 2,
+            BinderStyle::InstanceImplicit => 3,
+        }
+    }
+}
+
+impl From<u16> for BinderStyle {
+    fn from(v: u16) -> BinderStyle {
+        match v & 0x3 {
+            0 => BinderStyle::Default,
+            1 => BinderStyle::Implicit,
+            2 => BinderStyle::StrictImplicit,
+            3 => BinderStyle::InstanceImplicit,
+            _ => unreachable!(),
+        }
+    }
+}
+
+/// Pack num_loose_bvars, has_fvars, and binder_style into a single u16.
+/// Bits 0-12 = num_loose_bvars (max 8191), bit 13 = has_fvars, bits 14-15 = binder_style.
+pub(crate) fn pack_meta(num_loose_bvars: u16, has_fvars: bool, binder_style: BinderStyle) -> u16 {
+    (num_loose_bvars & 0x1FFF) | ((has_fvars as u16) << 13) | (u16::from(binder_style) << 14)
+}
+
+/// Pack num_loose_bvars and has_fvars into a single u16 (for App/Proj/Let which have no binder_style).
+/// Bits 0-12 = num_loose_bvars (max 8191), bit 13 = has_fvars, bits 14-15 = 0.
+pub(crate) fn pack_meta_no_binder(num_loose_bvars: u16, has_fvars: bool) -> u16 {
+    (num_loose_bvars & 0x1FFF) | ((has_fvars as u16) << 13)
+}
+
+/// Extract num_loose_bvars from packed meta (bits 0-12).
+pub(crate) fn meta_num_loose_bvars(meta: u16) -> u16 {
+    meta & 0x1FFF
+}
+
+/// Extract has_fvars from packed meta (bit 13).
+pub(crate) fn meta_has_fvars(meta: u16) -> bool {
+    (meta >> 13) & 1 != 0
+}
+
+/// Extract binder_style from packed meta (bits 14-15).
+pub(crate) fn meta_binder_style(meta: u16) -> BinderStyle {
+    BinderStyle::from(meta >> 14)
+}
+
 impl<'t, 'p: 't> TcCtx<'t, 'p> {
     pub(crate) fn inst_forall_params(&mut self, mut e: ExprPtr<'t>, n: usize, all_args: &[ExprPtr<'t>]) -> ExprPtr<'t> {
         for _ in 0..n {
@@ -185,12 +233,14 @@ impl<'t, 'p: 't> TcCtx<'t, 'p> {
                     let arg = self.inst_aux(arg, substs, offset);
                     self.mk_app(fun, arg)
                 }
-                Pi { binder_name, binder_style, binder_type, body, .. } => {
+                Pi { binder_name, binder_type, body, meta, .. } => {
+                    let binder_style = meta_binder_style(meta);
                     let binder_type = self.inst_aux(binder_type, substs, offset);
                     let body = self.inst_aux(body, substs, offset + 1);
                     self.mk_pi(binder_name, binder_style, binder_type, body)
                 }
-                Lambda { binder_name, binder_style, binder_type, body, .. } => {
+                Lambda { binder_name, binder_type, body, meta, .. } => {
+                    let binder_style = meta_binder_style(meta);
                     let binder_type = self.inst_aux(binder_type, substs, offset);
                     let body = self.inst_aux(body, substs, offset + 1);
                     self.mk_lambda(binder_name, binder_style, binder_type, body)
@@ -242,12 +292,14 @@ impl<'t, 'p: 't> TcCtx<'t, 'p> {
                     let arg = self.abstr_aux_levels(arg, start_pos, num_open_binders);
                     self.mk_app(fun, arg)
                 }
-                Pi { binder_name, binder_style, binder_type, body, .. } => {
+                Pi { binder_name, binder_type, body, meta, .. } => {
+                    let binder_style = meta_binder_style(meta);
                     let binder_type = self.abstr_aux_levels(binder_type, start_pos, num_open_binders);
                     let body = self.abstr_aux_levels(body, start_pos, num_open_binders + 1);
                     self.mk_pi(binder_name, binder_style, binder_type, body)
                 }
-                Lambda { binder_name, binder_style, binder_type, body, .. } => {
+                Lambda { binder_name, binder_type, body, meta, .. } => {
+                    let binder_style = meta_binder_style(meta);
                     let binder_type = self.abstr_aux_levels(binder_type, start_pos, num_open_binders);
                     let body = self.abstr_aux_levels(body, start_pos, num_open_binders + 1);
                     self.mk_lambda(binder_name, binder_style, binder_type, body)
@@ -294,12 +346,14 @@ impl<'t, 'p: 't> TcCtx<'t, 'p> {
                     let arg = self.abstr_aux(arg, locals, offset);
                     self.mk_app(fun, arg)
                 }
-                Pi { binder_name, binder_style, binder_type, body, .. } => {
+                Pi { binder_name, binder_type, body, meta, .. } => {
+                    let binder_style = meta_binder_style(meta);
                     let binder_type = self.abstr_aux(binder_type, locals, offset);
                     let body = self.abstr_aux(body, locals, offset + 1);
                     self.mk_pi(binder_name, binder_style, binder_type, body)
                 }
-                Lambda { binder_name, binder_style, binder_type, body, .. } => {
+                Lambda { binder_name, binder_type, body, meta, .. } => {
+                    let binder_style = meta_binder_style(meta);
                     let binder_type = self.abstr_aux(binder_type, locals, offset);
                     let body = self.abstr_aux(body, locals, offset + 1);
                     self.mk_lambda(binder_name, binder_style, binder_type, body)
@@ -349,12 +403,14 @@ impl<'t, 'p: 't> TcCtx<'t, 'p> {
                     let arg = self.subst_aux(arg, ks, vs);
                     self.mk_app(fun, arg)
                 }
-                Pi { binder_name, binder_style, binder_type, body, .. } => {
+                Pi { binder_name, binder_type, body, meta, .. } => {
+                    let binder_style = meta_binder_style(meta);
                     let binder_type = self.subst_aux(binder_type, ks, vs);
                     let body = self.subst_aux(body, ks, vs);
                     self.mk_pi(binder_name, binder_style, binder_type, body)
                 }
-                Lambda { binder_name, binder_style, binder_type, body, .. } => {
+                Lambda { binder_name, binder_type, body, meta, .. } => {
+                    let binder_style = meta_binder_style(meta);
                     let binder_type = self.subst_aux(binder_type, ks, vs);
                     let body = self.subst_aux(body, ks, vs);
                     self.mk_lambda(binder_name, binder_style, binder_type, body)
@@ -755,11 +811,11 @@ impl<'t> Expr<'t> {
         match self {
             Sort { .. } | Const { .. } | Local { .. } | StringLit { .. } | NatLit { .. } => 0,
             Var { dbj_idx, .. } => dbj_idx + 1,
-            App { num_loose_bvars, .. }
-            | Pi { num_loose_bvars, .. }
-            | Lambda { num_loose_bvars, .. }
-            | Let { num_loose_bvars, .. }
-            | Proj { num_loose_bvars, .. } => *num_loose_bvars,
+            App { meta, .. }
+            | Pi { meta, .. }
+            | Lambda { meta, .. }
+            | Let { meta, .. }
+            | Proj { meta, .. } => meta_num_loose_bvars(*meta),
         }
     }
 
@@ -767,11 +823,11 @@ impl<'t> Expr<'t> {
         match self {
             Local { .. } => true,
             Var { .. } | Sort { .. } | Const { .. } | NatLit { .. } | StringLit { .. } => false,
-            App { has_fvars, .. }
-            | Pi { has_fvars, .. }
-            | Lambda { has_fvars, .. }
-            | Let { has_fvars, .. }
-            | Proj { has_fvars, .. } => *has_fvars,
+            App { meta, .. }
+            | Pi { meta, .. }
+            | Lambda { meta, .. }
+            | Let { meta, .. }
+            | Proj { meta, .. } => meta_has_fvars(*meta),
         }
     }
 }

--- a/src/inductive.rs
+++ b/src/inductive.rs
@@ -337,7 +337,8 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
         let mut param_locals = Vec::with_capacity(num_params as usize);
         for _ in 0..num_params {
             match self.ctx.read_expr(e) {
-                Pi { binder_name, binder_style, binder_type, body, .. } => {
+                Pi { binder_name, binder_type, body, meta, .. } => {
+                    let binder_style = crate::expr::meta_binder_style(meta);
                     let local_ = self.ctx.mk_unique(binder_name, binder_style, binder_type);
                     e = self.ctx.inst(body, &[local_]);
                     e = self.whnf(e);
@@ -358,7 +359,8 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
         ind_ty_cursor = self.whnf(ind_ty_cursor);
         let mut indices_locals = Vec::new();
         let mut i = 0;
-        while let Pi { binder_name, binder_style, binder_type, body, .. } = self.ctx.read_expr(ind_ty_cursor) {
+        while let Pi { binder_name, binder_type, body, meta, .. } = self.ctx.read_expr(ind_ty_cursor) {
+            let binder_style = crate::expr::meta_binder_style(meta);
             if i < st.local_params.len() {
                 let local_ = st.local_params[i];
                 match self.ctx.read_expr(local_) {
@@ -396,7 +398,8 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
         let mut ind_ty_cursor = self.whnf(ind.ty);
         let mut indices_locals = Vec::new();
         let mut i = 0;
-        while let Pi { binder_name, binder_style, binder_type, body, .. } = self.ctx.read_expr(ind_ty_cursor) {
+        while let Pi { binder_name, binder_type, body, meta, .. } = self.ctx.read_expr(ind_ty_cursor) {
+            let binder_style = crate::expr::meta_binder_style(meta);
             if i < st.local_params.len() {
                 ind_ty_cursor = self.ctx.inst(body, &[st.local_params[i]]);
                 ind_ty_cursor = self.whnf(ind_ty_cursor);
@@ -618,12 +621,14 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
         } else {
             match self.ctx.read_expr(e) {
                 Var { .. } | Sort { .. } | Const { .. } | Local { .. } | NatLit { .. } | StringLit { .. } => e,
-                Pi { binder_name, binder_style, binder_type, body, .. } => {
+                Pi { binder_name, binder_type, body, meta, .. } => {
+                    let binder_style = crate::expr::meta_binder_style(meta);
                     let binder_type = self.replace_all_nested(binder_type, st, outgoing_params);
                     let body = self.replace_all_nested(body, st, outgoing_params);
                     self.ctx.mk_pi(binder_name, binder_style, binder_type, body)
                 }
-                Lambda { binder_name, binder_style, binder_type, body, .. } => {
+                Lambda { binder_name, binder_type, body, meta, .. } => {
+                    let binder_style = crate::expr::meta_binder_style(meta);
                     let binder_type = self.replace_all_nested(binder_type, st, outgoing_params);
                     let body = self.replace_all_nested(body, st, outgoing_params);
                     self.ctx.mk_lambda(binder_name, binder_style, binder_type, body)
@@ -668,7 +673,8 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
             ctor_type_cursor = self.whnf(ctor_type_cursor);
             match self.ctx.read_expr(ctor_type_cursor) {
                 _any if !self.has_ind_occ(ctor_type_cursor, st.ind_consts.as_ref()) => return,
-                Pi { binder_name, binder_style, binder_type, body, .. } => {
+                Pi { binder_name, binder_type, body, meta, .. } => {
+                    let binder_style = crate::expr::meta_binder_style(meta);
                     if self.has_ind_occ(binder_type, st.ind_consts.as_ref()) {
                         panic!("non-positive occurrence");
                     }
@@ -804,7 +810,8 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
             }
         }
         // Non-param constructor args.
-        while let Pi { binder_name, binder_type, binder_style, body, .. } = self.ctx.read_expr(ctor_type_cursor) {
+        while let Pi { binder_name, binder_type, body, meta, .. } = self.ctx.read_expr(ctor_type_cursor) {
+            let binder_style = crate::expr::meta_binder_style(meta);
             let s = self.ensure_infers_as_sort(binder_type);
             // The inductive being constructed either has to be a `Prop`,
             // or the constructor argument's type has to be <= the inductive's
@@ -847,12 +854,14 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
         let mut non_prop_ctor_telescope_elems = Vec::new();
         loop {
             match self.ctx.read_expr(ctor_type_cursor) {
-                Pi { binder_name, binder_style, binder_type, body, .. } if rem_params != 0 => {
+                Pi { binder_name, binder_type, body, meta, .. } if rem_params != 0 => {
+                    let binder_style = crate::expr::meta_binder_style(meta);
                     let local = self.ctx.mk_unique(binder_name, binder_style, binder_type);
                     ctor_type_cursor = self.ctx.inst(body, &[local]);
                     rem_params -= 1;
                 }
-                Pi { binder_name, binder_style, binder_type, body, .. } => {
+                Pi { binder_name, binder_type, body, meta, .. } => {
+                    let binder_style = crate::expr::meta_binder_style(meta);
                     let local = self.ctx.mk_unique(binder_name, binder_style, binder_type);
                     ctor_type_cursor = self.ctx.inst(body, &[local]);
                     let binder_type_level = self.ensure_infers_as_sort(binder_type);
@@ -989,7 +998,8 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
 
     fn is_rec_argument(&mut self, st: &InductiveCheckState<'t>, mut ctor_btype_cursor: ExprPtr<'t>) -> Option<usize> {
         ctor_btype_cursor = self.whnf(ctor_btype_cursor);
-        if let Pi { binder_name, binder_style, binder_type, body, .. } = self.ctx.read_expr(ctor_btype_cursor) {
+        if let Pi { binder_name, binder_type, body, meta, .. } = self.ctx.read_expr(ctor_btype_cursor) {
+            let binder_style = crate::expr::meta_binder_style(meta);
             let local = self.ctx.mk_unique(binder_name, binder_style, binder_type);
             ctor_btype_cursor = self.ctx.inst(body, &[local]);
             self.is_rec_argument(st, ctor_btype_cursor)
@@ -1000,7 +1010,8 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
 
     fn handle_rec_args_aux(&mut self, mut rec_arg_cursor: ExprPtr<'t>) -> (ExprPtr<'t>, Vec<ExprPtr<'t>>) {
         let mut xs = Vec::new();
-        while let Pi { binder_name, binder_style, binder_type, body, .. } = self.ctx.read_expr(rec_arg_cursor) {
+        while let Pi { binder_name, binder_type, body, meta, .. } = self.ctx.read_expr(rec_arg_cursor) {
+            let binder_style = crate::expr::meta_binder_style(meta);
             let local = self.ctx.mk_unique(binder_name, binder_style, binder_type);
             rec_arg_cursor = self.ctx.inst(body, &[local]);
             rec_arg_cursor = self.whnf(rec_arg_cursor);
@@ -1026,7 +1037,8 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
                 _ => panic!(),
             }
         }
-        while let Pi { binder_name, binder_style, binder_type, body, .. } = self.ctx.read_expr(ctor_type_cursor) {
+        while let Pi { binder_name, binder_type, body, meta, .. } = self.ctx.read_expr(ctor_type_cursor) {
+            let binder_style = crate::expr::meta_binder_style(meta);
             let local = self.ctx.mk_unique(binder_name, binder_style, binder_type);
             ctor_type_cursor = self.ctx.inst(body, &[local]);
             all_args.push(local);
@@ -1393,7 +1405,8 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
             Some(out) => out,
             None => match self.ctx.read_expr(e) {
                 Var { .. } | Sort { .. } | Const { .. } | Local { .. } | StringLit { .. } | NatLit { .. } => e,
-                Lambda { binder_name, binder_style, binder_type, body, .. } => {
+                Lambda { binder_name, binder_type, body, meta, .. } => {
+                    let binder_style = crate::expr::meta_binder_style(meta);
                     let binder_type = self.restore_replace(
                         binder_type,
                         local_params,
@@ -1404,7 +1417,8 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
                         self.restore_replace(body, local_params, st, specialized_rec_names_to_unspecialized_rec_names);
                     self.ctx.mk_lambda(binder_name, binder_style, binder_type, body)
                 }
-                Pi { binder_name, binder_style, binder_type, body, .. } => {
+                Pi { binder_name, binder_type, body, meta, .. } => {
+                    let binder_style = crate::expr::meta_binder_style(meta);
                     let binder_type = self.restore_replace(
                         binder_type,
                         local_params,
@@ -1523,8 +1537,9 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
         for _ in 0..st.local_params.len() {
             match self.ctx.read_expr(e) {
                 // Also match on Lambda for restoring recursor rules.
-                Pi { binder_name, binder_style, binder_type, body, .. }
-                | Lambda { binder_name, binder_style, binder_type, body, .. } => {
+                Pi { binder_name, binder_type, body, meta, .. }
+                | Lambda { binder_name, binder_type, body, meta, .. } => {
+                    let binder_style = crate::expr::meta_binder_style(meta);
                     let local = self.ctx.mk_unique(binder_name, binder_style, binder_type);
                     e = self.ctx.inst(body, &[local]);
                     locals.push(local);

--- a/src/level.rs
+++ b/src/level.rs
@@ -18,7 +18,7 @@ pub enum Level<'a> {
 }
 
 impl<'a> Level<'a> {
-    fn get_hash(&self) -> u64 {
+    pub(crate) fn get_hash(&self) -> u64 {
         match self {
             Zero => ZERO_HASH,
             Succ(.., hash) | Max(.., hash) | IMax(.., hash) | Param(.., hash) => *hash,

--- a/src/name.rs
+++ b/src/name.rs
@@ -18,7 +18,7 @@ impl<'a> std::hash::Hash for Name<'a> {
 }
 
 impl<'a> Name<'a> {
-    fn get_hash(&self) -> u64 {
+    pub(crate) fn get_hash(&self) -> u64 {
         match self {
             Anon => ANON_HASH,
             Str(.., hash) | Num(.., hash) => *hash,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -618,7 +618,8 @@ impl<'a, R: BufRead> Parser<'a, R> {
                     let hash = hash64!(crate::expr::APP_HASH, fun, arg);
                     let num_bvars = self.num_loose_bvars(fun).max(self.num_loose_bvars(arg));
                     let locals = self.has_fvars(fun) || self.has_fvars(arg);
-                    self.dag.exprs.insert_full(Expr::App { fun, arg, num_loose_bvars: num_bvars, has_fvars: locals, hash })
+                    let meta = crate::expr::pack_meta_no_binder(num_bvars, locals);
+                    self.dag.exprs.insert_full(Expr::App { fun, arg, meta, hash })
                 };
                 assigned_idx.unwrap().assert_ie(insert_result);
             }
@@ -637,13 +638,12 @@ impl<'a, R: BufRead> Parser<'a, R> {
                     let hash = hash64!(crate::expr::LAMBDA_HASH, binder_name, binder_info, binder_type, body);
                     let num_bvars = self.num_loose_bvars(binder_type).max(self.num_loose_bvars(body).saturating_sub(1));
                     let locals = self.has_fvars(binder_type) || self.has_fvars(body);
+                    let meta = crate::expr::pack_meta(num_bvars, locals, binder_info);
                     self.dag.exprs.insert_full(Expr::Lambda {
                         binder_name,
-                        binder_style: binder_info,
                         binder_type,
                         body,
-                        num_loose_bvars: num_bvars,
-                        has_fvars: locals,
+                        meta,
                         hash,
                     })
                 };
@@ -657,13 +657,12 @@ impl<'a, R: BufRead> Parser<'a, R> {
                     let hash = hash64!(crate::expr::PI_HASH, binder_name, binder_info, binder_type, body);
                     let num_bvars = self.num_loose_bvars(binder_type).max(self.num_loose_bvars(body).saturating_sub(1));
                     let locals = self.has_fvars(binder_type) || self.has_fvars(body);
+                    let meta = crate::expr::pack_meta(num_bvars, locals, binder_info);
                     self.dag.exprs.insert_full(Expr::Pi {
                         binder_name,
-                        binder_style: binder_info,
                         binder_type,
                         body,
-                        num_loose_bvars: num_bvars,
-                        has_fvars: locals,
+                        meta,
                         hash,
                     })
                 };
@@ -680,13 +679,13 @@ impl<'a, R: BufRead> Parser<'a, R> {
                         .num_loose_bvars(binder_type)
                         .max(self.num_loose_bvars(val).max(self.num_loose_bvars(body).saturating_sub(1)));
                     let locals = self.has_fvars(binder_type) || self.has_fvars(val) || self.has_fvars(body);
+                    let meta = crate::expr::pack_meta_no_binder(num_bvars, locals);
                     self.dag.exprs.insert_full(Expr::Let {
                         binder_name,
                         binder_type,
                         val,
                         body,
-                        num_loose_bvars: num_bvars,
-                        has_fvars: locals,
+                        meta,
                         hash,
                         nondep
                     })
@@ -700,12 +699,12 @@ impl<'a, R: BufRead> Parser<'a, R> {
                     let hash = hash64!(crate::expr::PROJ_HASH, ty_name, idx, structure);
                     let num_bvars = self.num_loose_bvars(structure);
                     let locals = self.has_fvars(structure);
+                    let meta = crate::expr::pack_meta_no_binder(num_bvars, locals);
                     self.dag.exprs.insert_full(Expr::Proj {
                         ty_name,
                         idx,
                         structure,
-                        num_loose_bvars: num_bvars,
-                        has_fvars: locals,
+                        meta,
                         hash,
                     })
                 };

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -495,7 +495,8 @@ impl<'a, R: BufRead> Parser<'a, R> {
 
     fn go1(&mut self, line: &str) -> Result<(), Box<dyn Error>> {
         use ExportJsonVal::*;
-        let ExportJsonObject {val, i: assigned_idx} = serde_json::from_str::<ExportJsonObject>(line)?;
+        let mut line_bytes = line.as_bytes().to_vec(); // simd-json needs mutable bytes
+        let ExportJsonObject {val, i: assigned_idx} = simd_json::serde::from_slice::<ExportJsonObject>(&mut line_bytes)?;
         match val {
             Metadata(json_val) => {
                 let _ = check_semver(&json_val)?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -452,7 +452,7 @@ impl<'a, R: BufRead> Parser<'a, R> {
             let name_ptr = self.get_name_ptr(name_idx);
             let hash = hash64!(crate::level::PARAM_HASH, name_ptr);
             // Has to already exist
-            let idx = self.dag.levels.get_index_of(&Level::Param(name_ptr, hash)).unwrap();
+            let idx = self.dag.levels.get_index_of_prehashed(hash, &Level::Param(name_ptr, hash)).unwrap();
             levels.push(LevelPtr::from(DagMarker::ExportFile, idx as usize));
         }
         LevelsPtr::from(DagMarker::ExportFile, self.dag.uparams.insert_full(Arc::from(levels)).0)
@@ -510,7 +510,7 @@ impl<'a, R: BufRead> Parser<'a, R> {
 
                 let insert_result = {
                     let hash = hash64!(crate::name::STR_HASH, pfx, sfx);
-                    self.dag.names.insert_full(Name::Str(pfx, sfx, hash))
+                    self.dag.names.insert_prehashed(hash, Name::Str(pfx, sfx, hash))
                 };
                 assigned_idx.unwrap().assert_in(insert_result);
             }
@@ -519,7 +519,7 @@ impl<'a, R: BufRead> Parser<'a, R> {
                 let sfx = i as u64;
                 let insert_result = {
                     let hash = hash64!(crate::name::NUM_HASH, pfx, sfx);
-                    self.dag.names.insert_full(Name::Num(pfx, sfx, hash))
+                    self.dag.names.insert_prehashed(hash, Name::Num(pfx, sfx, hash))
                 };
                 assigned_idx.unwrap().assert_in(insert_result);
             }
@@ -532,7 +532,7 @@ impl<'a, R: BufRead> Parser<'a, R> {
                 let num_ptr = BigUintPtr::from(DagMarker::ExportFile, self.dag.bignums.as_mut().unwrap().insert_full(big_uint).0);
                 let insert_result = {
                     let hash = hash64!(crate::expr::NAT_LIT_HASH, num_ptr);
-                    self.dag.exprs.insert_full(Expr::NatLit { ptr: num_ptr, hash })
+                    self.dag.exprs.insert_prehashed(hash, Expr::NatLit { ptr: num_ptr, hash })
                 };
                 if !self.config.nat_extension {
                     return Err(Box::<dyn Error>::from(
@@ -554,7 +554,7 @@ impl<'a, R: BufRead> Parser<'a, R> {
                 );
                 let insert_result = {
                     let hash = hash64!(crate::expr::STRING_LIT_HASH, string_ptr);
-                    self.dag.exprs.insert_full(Expr::StringLit { ptr: string_ptr, hash })
+                    self.dag.exprs.insert_prehashed(hash, Expr::StringLit { ptr: string_ptr, hash })
                 };
                 assigned_idx.unwrap().assert_ie(insert_result);
             }
@@ -562,7 +562,7 @@ impl<'a, R: BufRead> Parser<'a, R> {
                 let l = self.get_level_ptr(l);
                 let insert_result = {
                     let hash = hash64!(crate::level::SUCC_HASH, l);
-                    self.dag.levels.insert_full(Level::Succ(l, hash))
+                    self.dag.levels.insert_prehashed(hash, Level::Succ(l, hash))
                 };
                 assigned_idx.unwrap().assert_il(insert_result);
             }
@@ -571,7 +571,7 @@ impl<'a, R: BufRead> Parser<'a, R> {
                 let r = self.get_level_ptr(r);
                 let insert_result = {
                     let hash = hash64!(crate::level::MAX_HASH, l, r);
-                    self.dag.levels.insert_full(Level::Max(l, r, hash))
+                    self.dag.levels.insert_prehashed(hash, Level::Max(l, r, hash))
                 };
                 assigned_idx.unwrap().assert_il(insert_result);
             }
@@ -580,7 +580,7 @@ impl<'a, R: BufRead> Parser<'a, R> {
                 let r = self.get_level_ptr(r);
                 let insert_result = {
                     let hash = hash64!(crate::level::IMAX_HASH, l, r);
-                    self.dag.levels.insert_full(Level::IMax(l, r, hash))
+                    self.dag.levels.insert_prehashed(hash, Level::IMax(l, r, hash))
                 };
                 assigned_idx.unwrap().assert_il(insert_result);
             }
@@ -588,7 +588,7 @@ impl<'a, R: BufRead> Parser<'a, R> {
                  let n = self.get_name_ptr(var_idx);
                  let insert_result = {
                      let hash = hash64!(crate::level::PARAM_HASH, n);
-                     self.dag.levels.insert_full(Level::Param(n, hash))
+                     self.dag.levels.insert_prehashed(hash, Level::Param(n, hash))
                  };
                 assigned_idx.unwrap().assert_il(insert_result);
             }
@@ -596,7 +596,7 @@ impl<'a, R: BufRead> Parser<'a, R> {
                 let level = self.get_level_ptr(level);
                 let insert_result = {
                     let hash = hash64!(crate::expr::SORT_HASH, level);
-                    self.dag.exprs.insert_full(Expr::Sort { level, hash })
+                    self.dag.exprs.insert_prehashed(hash, Expr::Sort { level, hash })
                 };
                 assigned_idx.unwrap().assert_ie(insert_result);
             }
@@ -608,7 +608,7 @@ impl<'a, R: BufRead> Parser<'a, R> {
                 let levels = self.get_levels_ptr(&levels);
                 let insert_result = {
                     let hash = hash64!(crate::expr::CONST_HASH, name, levels);
-                    self.dag.exprs.insert_full(Expr::Const { name, levels, hash })
+                    self.dag.exprs.insert_prehashed(hash, Expr::Const { name, levels, hash })
                 };
                 assigned_idx.unwrap().assert_ie(insert_result);
             }
@@ -620,14 +620,14 @@ impl<'a, R: BufRead> Parser<'a, R> {
                     let num_bvars = self.num_loose_bvars(fun).max(self.num_loose_bvars(arg));
                     let locals = self.has_fvars(fun) || self.has_fvars(arg);
                     let meta = crate::expr::pack_meta_no_binder(num_bvars, locals);
-                    self.dag.exprs.insert_full(Expr::App { fun, arg, meta, hash })
+                    self.dag.exprs.insert_prehashed(hash, Expr::App { fun, arg, meta, hash })
                 };
                 assigned_idx.unwrap().assert_ie(insert_result);
             }
             ExprBVar(dbj_idx) => {
                 let insert_result = {
                     let hash = hash64!(crate::expr::VAR_HASH, dbj_idx);
-                    self.dag.exprs.insert_full(Expr::Var { dbj_idx, hash })
+                    self.dag.exprs.insert_prehashed(hash, Expr::Var { dbj_idx, hash })
                 };
                 assigned_idx.unwrap().assert_ie(insert_result);
             }
@@ -640,7 +640,7 @@ impl<'a, R: BufRead> Parser<'a, R> {
                     let num_bvars = self.num_loose_bvars(binder_type).max(self.num_loose_bvars(body).saturating_sub(1));
                     let locals = self.has_fvars(binder_type) || self.has_fvars(body);
                     let meta = crate::expr::pack_meta(num_bvars, locals, binder_info);
-                    self.dag.exprs.insert_full(Expr::Lambda {
+                    self.dag.exprs.insert_prehashed(hash, Expr::Lambda {
                         binder_name,
                         binder_type,
                         body,
@@ -659,7 +659,7 @@ impl<'a, R: BufRead> Parser<'a, R> {
                     let num_bvars = self.num_loose_bvars(binder_type).max(self.num_loose_bvars(body).saturating_sub(1));
                     let locals = self.has_fvars(binder_type) || self.has_fvars(body);
                     let meta = crate::expr::pack_meta(num_bvars, locals, binder_info);
-                    self.dag.exprs.insert_full(Expr::Pi {
+                    self.dag.exprs.insert_prehashed(hash, Expr::Pi {
                         binder_name,
                         binder_type,
                         body,
@@ -681,7 +681,7 @@ impl<'a, R: BufRead> Parser<'a, R> {
                         .max(self.num_loose_bvars(val).max(self.num_loose_bvars(body).saturating_sub(1)));
                     let locals = self.has_fvars(binder_type) || self.has_fvars(val) || self.has_fvars(body);
                     let meta = crate::expr::pack_meta_no_binder(num_bvars, locals);
-                    self.dag.exprs.insert_full(Expr::Let {
+                    self.dag.exprs.insert_prehashed(hash, Expr::Let {
                         binder_name,
                         binder_type,
                         val,
@@ -701,7 +701,7 @@ impl<'a, R: BufRead> Parser<'a, R> {
                     let num_bvars = self.num_loose_bvars(structure);
                     let locals = self.has_fvars(structure);
                     let meta = crate::expr::pack_meta_no_binder(num_bvars, locals);
-                    self.dag.exprs.insert_full(Expr::Proj {
+                    self.dag.exprs.insert_prehashed(hash, Expr::Proj {
                         ty_name,
                         idx,
                         structure,

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -527,9 +527,10 @@ impl<'x, 't, 'p> PrettyPrinter<'x, 't, 'p> {
     /// later, etc.
     fn parse_binders(&mut self, mut e: ExprPtr<'t>) -> (Vec<ParsedBinder<'t>>, ExprPtr<'t>) {
         let (mut binders, mut binder_tys) = (Vec::<ParsedBinder>::new(), Vec::new());
-        while let Pi { binder_name, binder_style, binder_type, body, .. }
-        | Lambda { binder_name, binder_style, binder_type, body, .. } = self.ctx.read_expr(e)
+        while let Pi { binder_name, binder_type, body, meta, .. }
+        | Lambda { binder_name, binder_type, body, meta, .. } = self.ctx.read_expr(e)
         {
+            let binder_style = crate::expr::meta_binder_style(meta);
             let binder_type = self.ctx.inst(binder_type, binder_tys.as_slice());
             let local = self.ctx.mk_unique(binder_name, binder_style, binder_type);
             let is_pi = matches!(self.ctx.read_expr(e), Pi { .. });
@@ -615,7 +616,7 @@ impl<'x, 't, 'p> PrettyPrinter<'x, 't, 'p> {
         self.ctx.with_tc(crate::env::EnvLimit::PpUnlimited, |tc| {
             let ty = tc.infer_then_whnf(fun, crate::tc::InferFlag::InferOnly);
             match tc.ctx.read_expr(ty) {
-                Pi { binder_style, .. } => binder_style != BinderStyle::Default,
+                Pi { meta, .. } => crate::expr::meta_binder_style(meta) != BinderStyle::Default,
                 _ => false,
             }
         })

--- a/src/tc.rs
+++ b/src/tc.rs
@@ -598,7 +598,8 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
     fn infer_lambda(&mut self, mut e: ExprPtr<'t>, flag: InferFlag) -> ExprPtr<'t> {
         let mut locals = Vec::new();
         let start_pos = self.ctx.dbj_level_counter;
-        while let Lambda { binder_name, binder_style, binder_type, body, .. } = self.ctx.read_expr(e) {
+        while let Lambda { binder_name, binder_type, body, meta, .. } = self.ctx.read_expr(e) {
+            let binder_style = crate::expr::meta_binder_style(meta);
             let binder_type = self.ctx.inst(binder_type, locals.as_slice());
             if let Check = flag {
                 self.infer_sort_of(binder_type, flag);
@@ -629,7 +630,8 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
         let mut universes = Vec::new();
         let mut locals = Vec::new();
         let c0 = self.ctx.dbj_level_counter;
-        while let Pi { binder_name, binder_style, binder_type, body, .. } = self.ctx.read_expr(e) {
+        while let Pi { binder_name, binder_type, body, meta, .. } = self.ctx.read_expr(e) {
+            let binder_style = crate::expr::meta_binder_style(meta);
             let binder_type = self.ctx.inst(binder_type, locals.as_slice());
             let dom_univ = self.infer_sort_of(binder_type, flag);
             universes.push(dom_univ);
@@ -687,7 +689,8 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
                 let arg = self.strong_reduce(arg, reduce_types, reduce_proofs);
                 self.ctx.mk_app(f, arg)
             }
-            Expr::Lambda {binder_name, binder_style, binder_type, body, ..} => {
+            Expr::Lambda {binder_name, binder_type, body, meta, ..} => {
+                let binder_style = crate::expr::meta_binder_style(meta);
                 let start_pos = self.ctx.dbj_level_counter;
                 let local = self.ctx.mk_dbj_level(binder_name, binder_style, binder_type);
                 let instd = self.ctx.inst(body, &[local]);
@@ -702,7 +705,8 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
                     _ => panic!()
                 }
             }
-            Expr::Pi {binder_name, binder_style, binder_type, body, ..} => {
+            Expr::Pi {binder_name, binder_type, body, meta, ..} => {
+                let binder_style = crate::expr::meta_binder_style(meta);
                 let start_pos = self.ctx.dbj_level_counter;
                 let local = self.ctx.mk_dbj_level(binder_name, binder_style, binder_type);
                 let instd = self.ctx.inst(body, &[local]);
@@ -846,14 +850,15 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
     fn def_eq_binder_aux(&mut self, mut x: ExprPtr<'t>, mut y: ExprPtr<'t>) -> Option<bool> {
         let mut locals = Vec::new();
         while let (
-            Pi { binder_name, binder_style, binder_type: t1, body: body1, .. },
+            Pi { binder_name, binder_type: t1, body: body1, meta, .. },
             Pi { binder_type: t2, body: body2, .. },
         )
         | (
-            Lambda { binder_name, binder_style, binder_type: t1, body: body1, .. },
+            Lambda { binder_name, binder_type: t1, body: body1, meta, .. },
             Lambda { binder_type: t2, body: body2, .. },
         ) = self.ctx.read_expr_pair(x, y)
         {
+            let binder_style = crate::expr::meta_binder_style(meta);
             let t1 = self.ctx.inst(t1, locals.as_slice());
             let t2 = self.ctx.inst(t2, locals.as_slice());
             if self.def_eq(t1, t2) {
@@ -1316,7 +1321,8 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
     fn try_eta_expansion_aux(&mut self, x: ExprPtr<'t>, y: ExprPtr<'t>) -> bool {
         if let Lambda { .. } = self.ctx.read_expr(x) {
             let y_ty = self.infer_then_whnf(y, InferOnly);
-            if let Pi { binder_name, binder_type, binder_style, .. } = self.ctx.read_expr(y_ty) {
+            if let Pi { binder_name, binder_type, meta, .. } = self.ctx.read_expr(y_ty) {
+                let binder_style = crate::expr::meta_binder_style(meta);
                 let v0 = self.ctx.mk_var(0);
                 let new_body = self.ctx.mk_app(y, v0);
                 let new_lambda = self.ctx.mk_lambda(binder_name, binder_style, binder_type, new_body);

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,6 +7,7 @@ use crate::tc::TypeChecker;
 use crate::union_find::UnionFind;
 use crate::unique_hasher::UniqueHasher;
 use indexmap::{IndexMap, IndexSet};
+use hashbrown::HashTable;
 use num_bigint::BigUint;
 use num_traits::{ Pow, identities::Zero };
 use num_integer::Integer;
@@ -27,6 +28,58 @@ use serde::Deserialize;
 pub(crate) const fn default_true() -> bool { true }
 
 pub(crate) type UniqueIndexSet<A> = IndexSet<A, BuildHasherDefault<UniqueHasher>>;
+
+/// A deduplicating vector backed by hashbrown::HashTable for O(1) lookup.
+/// Items stored in a dense Vec, HashTable stores indices with pre-computed hashes.
+pub struct DedupVec<T: Eq + std::hash::Hash> {
+    items: Vec<T>,
+    table: HashTable<u32>,
+}
+
+impl<T: Eq + std::hash::Hash + std::fmt::Debug> std::fmt::Debug for DedupVec<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_list().entries(self.items.iter()).finish()
+    }
+}
+
+impl<T: Eq + std::hash::Hash> DedupVec<T> {
+    pub fn new() -> Self { Self { items: Vec::new(), table: HashTable::new() } }
+    pub fn with_capacity(cap: usize) -> Self {
+        Self { items: Vec::with_capacity(cap), table: HashTable::with_capacity(cap) }
+    }
+    pub fn len(&self) -> usize { self.items.len() }
+    pub fn get_index(&self, idx: usize) -> Option<&T> { self.items.get(idx) }
+    pub fn get_index_of_prehashed(&self, hash: u64, item: &T) -> Option<usize> {
+        self.table.find(hash, |&idx| self.items[idx as usize] == *item).map(|&idx| idx as usize)
+    }
+    pub fn insert_prehashed(&mut self, hash: u64, item: T) -> (usize, bool) {
+        if let Some(&idx) = self.table.find(hash, |&idx| self.items[idx as usize] == item) {
+            return (idx as usize, false);
+        }
+        let idx = self.items.len() as u32;
+        self.items.push(item);
+        self.table.insert_unique(hash, idx, |&existing_idx| {
+            let existing = &self.items[existing_idx as usize];
+            let mut hasher = crate::unique_hasher::UniqueHasher::new();
+            std::hash::Hash::hash(existing, &mut hasher);
+            std::hash::Hasher::finish(&hasher)
+        });
+        (idx as usize, true)
+    }
+    pub fn insert_full(&mut self, item: T) -> (usize, bool) {
+        let mut hasher = crate::unique_hasher::UniqueHasher::new();
+        std::hash::Hash::hash(&item, &mut hasher);
+        let hash = std::hash::Hasher::finish(&hasher);
+        self.insert_prehashed(hash, item)
+    }
+    pub fn get_index_of(&self, item: &T) -> Option<usize> {
+        let mut hasher = crate::unique_hasher::UniqueHasher::new();
+        std::hash::Hash::hash(item, &mut hasher);
+        let hash = std::hash::Hasher::finish(&hasher);
+        self.get_index_of_prehashed(hash, item)
+    }
+}
+
 pub(crate) type FxIndexSet<A> = IndexSet<A, BuildHasherDefault<FxHasher>>;
 pub(crate) type FxIndexMap<K, V> = IndexMap<K, V, BuildHasherDefault<FxHasher>>;
 pub(crate) type FxHashMap<K, V> = HashMap<K, V, BuildHasherDefault<FxHasher>>;
@@ -382,10 +435,11 @@ impl<'t, 'p: 't> TcCtx<'t, 'p> {
     /// already stored, forego the allocation and return a pointer to the previously inserted
     /// element. Checks the longer-lived storage first.
     pub fn alloc_name(&mut self, n: Name<'t>) -> NamePtr<'t> {
-        if let Some(idx) = self.export_file.dag.names.get_index_of(&n) {
+        let hash = n.get_hash();
+        if let Some(idx) = self.export_file.dag.names.get_index_of_prehashed(hash, &n) {
             Ptr::from(DagMarker::ExportFile, idx)
         } else {
-            Ptr::from(DagMarker::TcCtx, self.dag.names.insert_full(n).0)
+            Ptr::from(DagMarker::TcCtx, self.dag.names.insert_prehashed(hash, n).0)
         }
     }
 
@@ -393,10 +447,11 @@ impl<'t, 'p: 't> TcCtx<'t, 'p> {
     /// already stored, forego the allocation and return a pointer to the previously inserted
     /// element. Checks the longer-lived storage first.
     pub fn alloc_level(&mut self, l: Level<'t>) -> LevelPtr<'t> {
-        if let Some(idx) = self.export_file.dag.levels.get_index_of(&l) {
+        let hash = l.get_hash();
+        if let Some(idx) = self.export_file.dag.levels.get_index_of_prehashed(hash, &l) {
             Ptr::from(DagMarker::ExportFile, idx)
         } else {
-            Ptr::from(DagMarker::TcCtx, self.dag.levels.insert_full(l).0)
+            Ptr::from(DagMarker::TcCtx, self.dag.levels.insert_prehashed(hash, l).0)
         }
     }
 
@@ -404,10 +459,11 @@ impl<'t, 'p: 't> TcCtx<'t, 'p> {
     /// already stored, forego the allocation and return a pointer to the previously inserted
     /// element. Checks the longer-lived storage first.
     pub fn alloc_expr(&mut self, e: Expr<'t>) -> ExprPtr<'t> {
-        if let Some(idx) = self.export_file.dag.exprs.get_index_of(&e) {
+        let hash = e.get_hash();
+        if let Some(idx) = self.export_file.dag.exprs.get_index_of_prehashed(hash, &e) {
             Ptr::from(DagMarker::ExportFile, idx)
         } else {
-            Ptr::from(DagMarker::TcCtx, self.dag.exprs.insert_full(e).0)
+            Ptr::from(DagMarker::TcCtx, self.dag.exprs.insert_prehashed(hash, e).0)
         }
     }
 
@@ -686,9 +742,9 @@ impl<'t, 'p: 't> TcCtx<'t, 'p> {
 
 #[derive(Debug)]
 pub struct LeanDag<'a> {
-    pub names: UniqueIndexSet<Name<'a>>,
-    pub levels: UniqueIndexSet<Level<'a>>,
-    pub exprs: UniqueIndexSet<Expr<'a>>,
+    pub names: DedupVec<Name<'a>>,
+    pub levels: DedupVec<Level<'a>>,
+    pub exprs: DedupVec<Expr<'a>>,
     pub uparams: FxIndexSet<Arc<[LevelPtr<'a>]>>,
     pub strings: FxIndexSet<CowStr<'a>>,
     pub bignums: Option<FxIndexSet<BigUint>>,
@@ -709,16 +765,16 @@ impl<'a> LeanDag<'a> {
     /// The hints are target capacities for names, levels, and exprs respectively.
     pub fn new_presized(config: &Config, name_hint: usize, level_hint: usize, expr_hint: usize) -> Self {
         let mut out = Self {
-            names: UniqueIndexSet::with_capacity_and_hasher(name_hint, Default::default()),
-            levels: UniqueIndexSet::with_capacity_and_hasher(level_hint, Default::default()),
-            exprs: UniqueIndexSet::with_capacity_and_hasher(expr_hint, Default::default()),
+            names: DedupVec::with_capacity(name_hint),
+            levels: DedupVec::with_capacity(level_hint),
+            exprs: DedupVec::with_capacity(expr_hint),
             uparams: FxIndexSet::with_capacity_and_hasher(16, Default::default()),
             strings: FxIndexSet::with_capacity_and_hasher(16, Default::default()),
             bignums: if config.nat_extension { Some(FxIndexSet::with_capacity_and_hasher(16, Default::default())) } else { None },
         };
 
-        let _ = out.names.insert(Name::Anon);
-        let _ = out.levels.insert(Level::Zero);
+        let _ = out.names.insert_full(Name::Anon);
+        let _ = out.levels.insert_full(Level::Zero);
         out
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -94,8 +94,7 @@ pub(crate) fn new_fx_hash_map<K, V>() -> FxHashMap<K, V> { FxHashMap::with_hashe
 
 pub(crate) fn new_fx_hash_set<K>() -> FxHashSet<K> { FxHashSet::with_hasher(Default::default()) }
 
-pub(crate) fn new_fx_index_set<K>() -> FxIndexSet<K> { FxIndexSet::with_hasher(Default::default()) }
-pub(crate) fn new_unique_index_set<K>() -> UniqueIndexSet<K> { UniqueIndexSet::with_hasher(Default::default()) }
+
 
 pub(crate) fn new_unique_hash_map<K, V>() -> UniqueHashMap<K, V> { UniqueHashMap::with_hasher(Default::default()) }
 
@@ -218,10 +217,21 @@ pub struct ExportFile<'p> {
 impl<'p> ExportFile<'p> {
     pub fn new_env(&self, env_limit: EnvLimit<'p>) -> Env<'_, '_> { Env::new(&self.declars, &self.notations, env_limit) }
 
+    /// Sizing hints for temporary DAGs, derived from the export file's own DAG.
+    /// A single declaration's working set is typically much smaller than the full export.
+    fn dag_hints(&self) -> (usize, usize, usize) {
+        (
+            self.dag.names.len() / 4,
+            self.dag.levels.len() / 4,
+            self.dag.exprs.len() / 4,
+        )
+    }
+
     pub fn with_ctx<F, A>(&self, f: F) -> A
     where
         F: FnOnce(&mut TcCtx<'_, 'p>) -> A, {
-        let mut dag = LeanDag::new(&self.config);
+        let (nh, lh, eh) = self.dag_hints();
+        let mut dag = LeanDag::new_presized(&self.config, nh, lh, eh);
         let mut ctx = TcCtx::new(self, &mut dag);
         f(&mut ctx)
     }
@@ -229,7 +239,8 @@ impl<'p> ExportFile<'p> {
     pub fn with_tc<F, A>(&self, env_limit: EnvLimit, f: F) -> A
     where
         F: FnOnce(&mut TypeChecker<'_, '_, 'p>) -> A, {
-        let mut dag = LeanDag::new(&self.config);
+        let (nh, lh, eh) = self.dag_hints();
+        let mut dag = LeanDag::new_presized(&self.config, nh, lh, eh);
         let mut ctx = TcCtx::new(self, &mut dag);
         let env = self.new_env(env_limit);
         let mut tc = TypeChecker::new(&mut ctx, &env, None);
@@ -239,7 +250,8 @@ impl<'p> ExportFile<'p> {
     pub fn with_tc_and_declar<F, A>(&self, d: crate::env::DeclarInfo<'p>, f: F) -> A
     where
         F: FnOnce(&mut TypeChecker<'_, '_, 'p>) -> A, {
-        let mut dag = LeanDag::new(&self.config);
+        let (nh, lh, eh) = self.dag_hints();
+        let mut dag = LeanDag::new_presized(&self.config, nh, lh, eh);
         let mut ctx = TcCtx::new(self, &mut dag);
         let env = self.new_env(EnvLimit::ByName(d.name));
         let mut tc = TypeChecker::new(&mut ctx, &env, Some(d));
@@ -685,13 +697,19 @@ impl<'a> LeanDag<'a> {
     /// So when creating a new parser, we need to begin by placing `Anon` and `Zero` in the 0th position
     /// of their backing storage, satisfying the exporter's assumption.
     pub fn new(config: &Config) -> Self {
+        Self::new_presized(config, 0, 0, 0)
+    }
+
+    /// Create a LeanDag with pre-sized IndexSets to avoid repeated rehashing.
+    /// The hints are target capacities for names, levels, and exprs respectively.
+    pub fn new_presized(config: &Config, name_hint: usize, level_hint: usize, expr_hint: usize) -> Self {
         let mut out = Self {
-            names: new_unique_index_set(),
-            levels: new_unique_index_set(),
-            exprs: new_unique_index_set(),
-            uparams: new_fx_index_set(),
-            strings: new_fx_index_set(),
-            bignums: if config.nat_extension { Some(new_fx_index_set()) } else { None },
+            names: UniqueIndexSet::with_capacity_and_hasher(name_hint, Default::default()),
+            levels: UniqueIndexSet::with_capacity_and_hasher(level_hint, Default::default()),
+            exprs: UniqueIndexSet::with_capacity_and_hasher(expr_hint, Default::default()),
+            uparams: FxIndexSet::with_capacity_and_hasher(16, Default::default()),
+            strings: FxIndexSet::with_capacity_and_hasher(16, Default::default()),
+            bignums: if config.nat_extension { Some(FxIndexSet::with_capacity_and_hasher(16, Default::default())) } else { None },
         };
 
         let _ = out.names.insert(Name::Anon);

--- a/src/util.rs
+++ b/src/util.rs
@@ -530,7 +530,8 @@ impl<'t, 'p: 't> TcCtx<'t, 'p> {
         let hash = hash64!(crate::expr::APP_HASH, fun, arg);
         let num_loose_bvars = self.num_loose_bvars(fun).max(self.num_loose_bvars(arg));
         let has_fvars = self.has_fvars(fun) || self.has_fvars(arg);
-        self.alloc_expr(Expr::App { fun, arg, num_loose_bvars, has_fvars, hash })
+        let meta = crate::expr::pack_meta_no_binder(num_loose_bvars, has_fvars);
+        self.alloc_expr(Expr::App { fun, arg, meta, hash })
     }
 
     pub fn mk_lambda(
@@ -543,7 +544,8 @@ impl<'t, 'p: 't> TcCtx<'t, 'p> {
         let hash = hash64!(crate::expr::LAMBDA_HASH, binder_name, binder_style, binder_type, body);
         let num_loose_bvars = self.num_loose_bvars(binder_type).max(self.num_loose_bvars(body).saturating_sub(1));
         let has_fvars = self.has_fvars(binder_type) || self.has_fvars(body);
-        self.alloc_expr(Expr::Lambda { binder_name, binder_style, binder_type, body, num_loose_bvars, has_fvars, hash })
+        let meta = crate::expr::pack_meta(num_loose_bvars, has_fvars, binder_style);
+        self.alloc_expr(Expr::Lambda { binder_name, binder_type, body, meta, hash })
     }
 
     pub fn mk_pi(
@@ -556,7 +558,8 @@ impl<'t, 'p: 't> TcCtx<'t, 'p> {
         let hash = hash64!(crate::expr::PI_HASH, binder_name, binder_style, binder_type, body);
         let num_loose_bvars = self.num_loose_bvars(binder_type).max(self.num_loose_bvars(body).saturating_sub(1));
         let has_fvars = self.has_fvars(binder_type) || self.has_fvars(body);
-        self.alloc_expr(Expr::Pi { binder_name, binder_style, binder_type, body, num_loose_bvars, has_fvars, hash })
+        let meta = crate::expr::pack_meta(num_loose_bvars, has_fvars, binder_style);
+        self.alloc_expr(Expr::Pi { binder_name, binder_type, body, meta, hash })
     }
 
     pub fn mk_let(
@@ -572,14 +575,16 @@ impl<'t, 'p: 't> TcCtx<'t, 'p> {
             .num_loose_bvars(binder_type)
             .max(self.num_loose_bvars(val).max(self.num_loose_bvars(body).saturating_sub(1)));
         let has_fvars = self.has_fvars(binder_type) || self.has_fvars(val) || self.has_fvars(body);
-        self.alloc_expr(Expr::Let { binder_name, binder_type, val, body, num_loose_bvars, has_fvars, hash, nondep })
+        let meta = crate::expr::pack_meta_no_binder(num_loose_bvars, has_fvars);
+        self.alloc_expr(Expr::Let { binder_name, binder_type, val, body, meta, hash, nondep })
     }
 
     pub fn mk_proj(&mut self, ty_name: NamePtr<'t>, idx: usize, structure: ExprPtr<'t>) -> ExprPtr<'t> {
         let hash = hash64!(crate::expr::PROJ_HASH, ty_name, idx, structure);
         let num_loose_bvars = self.num_loose_bvars(structure);
         let has_fvars = self.has_fvars(structure);
-        self.alloc_expr(Expr::Proj { ty_name, idx, structure, num_loose_bvars, has_fvars, hash })
+        let meta = crate::expr::pack_meta_no_binder(num_loose_bvars, has_fvars);
+        self.alloc_expr(Expr::Proj { ty_name, idx, structure, meta, hash })
     }
 
     pub fn mk_string_lit(&mut self, string_ptr: StringPtr<'t>) -> Option<ExprPtr<'t>> {


### PR DESCRIPTION
## Summary

- Pre-size TcCtx IndexSets based on export file DAG size
- Pack Expr binder_style/has_fvars/num_loose_bvars into u16
- Use simd-json for NDJSON export parsing
- Replace IndexSet with hashbrown HashTable + Vec for hash-consing

## Benchmarks

Measured with [hyperfine](https://github.com/sharkdp/hyperfine) wall-clock time on Lean Kernel Arena tests. Same rustc 1.94.1, pre-built binaries, 15 runs with warmup. Wall-clock was chosen over `perf stat` cycle counts which showed high variance between sessions.

- **grind-ring-5** (2439 decls): 1.34s -> 1.10s, **18% faster**
- **app-lam** (34 decls, heavy reduction): ~neutral (within 2%)