### PR TITLE
feat: add opt-in progress reporting for large exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ if `"unpermitted_axiom_hard_error"` is set to `true`, the presence of an axiom i
 
 If `"print_success_message"` is set to false, no additional output will be printed on success, and users should look to the platform-specific exit code. If `"pp_to_stdout"` is `true` and `"print_success_message"` is `false` the pretty printer output will still be written to stdout.
 
+`"print_progress"` enables progress reporting to stderr during type checking. When enabled, the checker logs each pipeline stage (parsing, checking, pretty printing) with timing information. This is useful for large exports (e.g. mathlib) where checking can take dozens of minutes. Disabled by default.
+
+`"print_progress_step"` controls how often individual declaration progress is reported (every N declarations). Defaults to `1000`. Set to `1` to log every declaration — useful for identifying stuck or slow declarations when running in serial mode. Set to `0` to disable per-declaration progress (only stage-level messages will be shown).
+
 An example configuration file:
 
 ```
@@ -72,6 +76,8 @@ An example configuration file:
         "width": 100,
         "declar_sep": "\n\n",
     },
-    "print_success_message": false
+    "print_success_message": false,
+    "print_progress": true,
+    "print_progress_step": 1000
 }
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use nanoda_lib::util::Config;
 use std::error::Error;
 use std::path::Path;
+use std::time::Instant;
 
 fn main() -> Result<(), MainError> {
     let mut args = std::env::args();
@@ -20,6 +21,7 @@ fn main() -> Result<(), MainError> {
 
 // Returns an optional success message.
 fn use_config(config_path: &Path) -> Result<Option<String>, Box<dyn Error>> {
+    let total_start = Instant::now();
     let cfg = Config::try_from(config_path)?;
     // Make sure the target pretty printer destination is accessible before doing any real work.
     let mut pp_destination = cfg.get_pp_destination()?;
@@ -28,6 +30,7 @@ fn use_config(config_path: &Path) -> Result<Option<String>, Box<dyn Error>> {
     export_file.check_all_declars();
     // Pretty print as necessary
     let pp_errs = export_file.pp_selected_declars(pp_destination.as_mut());
+    if export_file.config.print_progress { eprintln!("Total time: {:.1}s", total_start.elapsed().as_secs_f64()); }
     if export_file.config.print_success_message {
         if pp_errs.is_empty() {
             if skipped_axioms.is_empty() {

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -348,6 +348,13 @@ impl<'p> ExportFile<'p> {
     pub fn pp_selected_declars(&self, pp_destination: Option<&mut PpDestination>) -> Vec<Box<dyn std::error::Error>> {
         let mut errs = Vec::new();
         if let Some(pp_destination) = pp_destination {
+            if self.config.print_progress {
+                if let Some(ref path) = self.config.pp_output_path {
+                    eprintln!("Pretty printing to {}...", path.display());
+                } else {
+                    eprintln!("Pretty printing to stdout...");
+                }
+            }
             self.with_ctx(|ctx| {
                 let mut pp_declars = Vec::new();
                 if let Some(pp_declar_strings) = self.config.pp_declars.as_ref() {

--- a/src/tc.rs
+++ b/src/tc.rs
@@ -3,8 +3,8 @@ use crate::env::{ConstructorData, Declar, DeclarInfo, Env, InductiveData, RecRul
 use crate::expr::Expr;
 use crate::level::Level;
 use crate::util::{
-    nat_div, nat_mod, nat_sub, nat_gcd, nat_land, nat_lor, 
-    nat_xor, nat_shr, nat_shl, ExportFile, ExprPtr, LevelPtr, 
+    nat_div, nat_mod, nat_sub, nat_gcd, nat_land, nat_lor,
+    nat_xor, nat_shr, nat_shl, ExportFile, ExprPtr, LevelPtr,
     LevelsPtr, NamePtr, TcCache, TcCtx, StringPtr
 };
 use std::error::Error;
@@ -107,7 +107,12 @@ impl<'p> ExportFile<'p> {
 
     /// Check all declarations in this export file using a single thread.
     pub(crate) fn check_all_declars_serial(&self) {
-        for declar in self.declars.values() {
+        let total = self.declars.len();
+        let print_progress = self.config.print_progress;
+        for (i, (name, declar)) in self.declars.iter().enumerate() {
+            if print_progress {
+                self.print_progress(i + 1, total, *name);
+            }
             self.check_declar(declar);
         }
     }
@@ -118,6 +123,10 @@ impl<'p> ExportFile<'p> {
         use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
         use std::thread;
         let task_num = AtomicUsize::new(0);
+        let total = self.declars.len();
+        let print_progress = self.config.print_progress;
+        let step = self.config.print_progress_step;
+        let started_count = AtomicUsize::new(0);
         thread::scope(|sco| {
             let mut handles = Vec::new();
             for i in 0..num_threads {
@@ -127,7 +136,11 @@ impl<'p> ExportFile<'p> {
                         .stack_size(crate::STACK_SIZE)
                         .spawn_scoped(sco, || loop {
                             let idx = task_num.fetch_add(1, Relaxed);
-                            if let Some((_, declar)) = self.declars.get_index(idx) {
+                            if let Some((name, declar)) = self.declars.get_index(idx) {
+                                if print_progress && step > 0 {
+                                    let started = started_count.fetch_add(1, Relaxed) + 1;
+                                    self.print_progress(started, total, *name);
+                                }
                                 self.check_declar(declar);
                             } else {
                                 break
@@ -143,12 +156,24 @@ impl<'p> ExportFile<'p> {
     }
 
     /// Check all of the declarations in this export file on the specified number
-    /// of threads (checking will be serial on the main thread is num_threads <= 1).
+    /// of threads (checking will be serial on the main thread if num_threads <= 1).
     pub fn check_all_declars(&self) {
+        let print_progress = self.config.print_progress;
+        let start = std::time::Instant::now();
         if self.config.num_threads > 1 {
+            if print_progress {
+                eprintln!("Checking {} declarations with {} workers...", self.declars.len(), self.config.num_threads);
+            }
             self.check_all_declars_par(self.config.num_threads)
         } else {
+            if print_progress {
+                eprintln!("Checking {} declarations (serial)...", self.declars.len());
+            }
             self.check_all_declars_serial()
+        }
+        if print_progress {
+            if self.config.is_tty { eprint!("\r\x1b[K"); }
+            eprintln!("Checked all {} declarations in {:.1}s", self.declars.len(), start.elapsed().as_secs_f64());
         }
     }
 }
@@ -156,7 +181,7 @@ impl<'p> ExportFile<'p> {
 impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
     pub fn new(dag: &'x mut TcCtx<'t, 'p>, env: &'x Env<'x, 't>, declar_info: Option<DeclarInfo<'t>>) -> Self {
         assert_eq!(dag.dbj_level_counter, 0);
-        Self { ctx: dag, env, tc_cache: TcCache::new(), declar_info } 
+        Self { ctx: dag, env, tc_cache: TcCache::new(), declar_info }
     }
 
     /// Conduct the preliminary checks done on all declarations; a declaration
@@ -170,7 +195,7 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
         let inferred_type = self.infer(info.ty, Check);
         let sort = self.ensure_sort(inferred_type);
 
-        // This is sort of a "soft" check in terms of soundness, but for theorems, ensure 
+        // This is sort of a "soft" check in terms of soundness, but for theorems, ensure
         // that they're propositions.
         if let Declar::Theorem {..} = d {
             if !self.ctx.is_zero(sort) {
@@ -179,7 +204,7 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
                     self.ctx.debug_print(sort)
                 )))
             }
-        } 
+        }
         Ok(())
     }
 
@@ -358,7 +383,7 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
             Ble => self.ctx.bool_to_expr(arg1 <= arg2),
         }
     }
-    
+
     /// Try to reduce an expression `e` which is an application of `Nat.succ`,
     /// or an application of a supported binary operation. `e` must have no free
     /// variables.
@@ -545,7 +570,7 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
                         if self.ctx.is_eager_reduce_app(arg) {
                             self.ctx.eager_mode = true;
                         }
-                        // `arg_type` and `binder_type` get swapped here to accommodate the 
+                        // `arg_type` and `binder_type` get swapped here to accommodate the
                         // eager reduction branch in `def_eq` being focused on reducing the lhs.
                         self.assert_def_eq(binder_type, arg_type);
                         // replace the outer scope's setting before next iteration
@@ -663,7 +688,7 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
         let body = self.ctx.inst(body, &[val]);
         self.infer(body, flag)
     }
-    
+
     // Not well tested, used for introspection/debugging.
     #[allow(dead_code)]
     pub(crate) fn strong_reduce(&mut self, e: ExprPtr<'t>, reduce_types: bool, reduce_proofs: bool) -> ExprPtr<'t> {
@@ -726,7 +751,7 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
                 } else {
                     x
                 }
-                
+
             }
             _ => e
         };
@@ -1038,7 +1063,7 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
             }
         }
     }
-    
+
     fn reduce_rec(
         &mut self,
         const_name: NamePtr<'t>,

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -28,8 +28,11 @@ pub(crate) fn test_get_export_file<'p>(config_path: Option<&Path>) -> Result<(Ex
             pp_to_stdout: false,
             num_threads: 1,
             print_success_message: true,
+            print_progress: false,
+            print_progress_step: 0,
             print_axioms: true,
-            unsafe_permit_all_axioms: false
+            unsafe_permit_all_axioms: false,
+            is_tty: false,
         },
         Some(config_path) => Config::try_from(config_path)?,
     };

--- a/src/util.rs
+++ b/src/util.rs
@@ -25,6 +25,7 @@ use std::sync::Arc;
 use serde::Deserialize;
 
 pub(crate) const fn default_true() -> bool { true }
+pub(crate) const fn default_progress_step() -> usize { 1000 }
 
 pub(crate) type UniqueIndexSet<A> = IndexSet<A, BuildHasherDefault<UniqueHasher>>;
 pub(crate) type FxIndexSet<A> = IndexSet<A, BuildHasherDefault<FxHasher>>;
@@ -217,6 +218,57 @@ pub struct ExportFile<'p> {
 
 impl<'p> ExportFile<'p> {
     pub fn new_env(&self, env_limit: EnvLimit<'p>) -> Env<'_, '_> { Env::new(&self.declars, &self.notations, env_limit) }
+
+    fn format_name(&self, p: NamePtr<'p>, buf: &mut String) {
+        use std::fmt::Write;
+        let name = *self.dag.names.get_index(p.idx()).unwrap();
+        match name {
+            Name::Anon => {}
+            Name::Str(pfx, sfx, _) => {
+                self.format_name_prefix(pfx, buf);
+                let s = self.dag.strings.get_index(sfx.idx()).unwrap();
+                let _ = write!(buf, "{}", s);
+            }
+            Name::Num(pfx, sfx, _) => {
+                self.format_name_prefix(pfx, buf);
+                let _ = write!(buf, "{}", sfx);
+            }
+        }
+    }
+
+    fn format_name_prefix(&self, pfx: NamePtr<'p>, buf: &mut String) {
+        let pfx_name = *self.dag.names.get_index(pfx.idx()).unwrap();
+        if !matches!(pfx_name, Name::Anon) {
+            self.format_name(pfx, buf);
+            buf.push('.');
+        }
+    }
+
+    /// Print a progress line like `[current/total] name` if progress reporting
+    /// is enabled and `current` aligns with the configured step.
+    pub fn print_progress(&self, current: usize, total: usize, name: NamePtr<'p>) {
+        if !self.config.print_progress {
+            return;
+        }
+        let step = self.config.print_progress_step;
+        if step > 0 && current % step == 0 {
+            let mut buf = String::new();
+            self.format_name(name, &mut buf);
+            if buf.len() > 120 {
+                let mut end = 117;
+                while !buf.is_char_boundary(end) {
+                    end -= 1;
+                }
+                buf.truncate(end);
+                buf.push_str("...");
+            }
+            if self.config.is_tty {
+                eprint!("\r\x1b[K[{}/{}] {}", current, total, buf);
+            } else {
+                eprintln!("[{}/{}] {}", current, total, buf);
+            }
+        }
+    }
 
     pub fn with_ctx<F, A>(&self, f: F) -> A
     where
@@ -904,15 +956,27 @@ pub struct Config {
     #[serde(default)]
     pub print_success_message: bool,
 
+    /// Whether to print progress messages to stderr during type checking.
+    #[serde(default)]
+    pub print_progress: bool,
+
+    /// How often to print progress (every N declarations). If 0, progress is not printed.
+    #[serde(default = "default_progress_step")]
+    pub print_progress_step: usize,
+
     /// If `true`, the typechecker will print the axioms actually admitted to the environment
     /// when typechecking is finished. 
     #[serde(default = "default_true")]
     pub print_axioms: bool,
 
-    /// If set to `true`, will allow all axioms to be admitted to the environment. 
+    /// If set to `true`, will allow all axioms to be admitted to the environment.
     /// This is checked so as to be mutually exclusive with any of the axiom allow list/whitelist features.
     #[serde(default)]
     pub unsafe_permit_all_axioms: bool,
+
+    /// Whether stderr is a terminal (computed at startup, not from config file).
+    #[serde(skip)]
+    pub is_tty: bool,
 }
 
 impl TryFrom<&Path> for Config {
@@ -921,7 +985,9 @@ impl TryFrom<&Path> for Config {
         match OpenOptions::new().read(true).truncate(false).open(p) {
             Err(e) => Err(Box::from(format!("failed to open configuration file: {:?}", e))),
             Ok(config_file) => {
-                let config = serde_json::from_reader::<_, Config>(BufReader::new(config_file)).unwrap();
+                use std::io::IsTerminal;
+                let mut config = serde_json::from_reader::<_, Config>(BufReader::new(config_file)).unwrap();
+                config.is_tty = std::io::stderr().is_terminal();
                 if config.export_file_path.is_none() && !config.use_stdin {
                     return Err(Box::from(format!("incompatible config options: must specify a path to an export file OR set `use_stdin: true`")))
                 }
@@ -974,14 +1040,34 @@ impl Config {
     // Returns the export file, and a list of strings representing the names of "skipped" axioms
     // (axioms which were in the export file, but not allowed by the execution config).
     pub fn to_export_file<'a>(self) -> Result<(ExportFile<'a>, Vec<String>), Box<dyn Error>> {
+        let print_progress = self.print_progress;
+        let log_parsed = |start: std::time::Instant, result: &Result<(ExportFile<'_>, Vec<String>), Box<dyn Error>>| {
+            if let Ok((ref ef, _)) = result {
+                eprintln!("Parsed {} declarations in {:.1}s", ef.declars.len(), start.elapsed().as_secs_f64());
+            }
+        };
         if let Some(pathbuf) = self.export_file_path.as_ref() {
+            if print_progress {
+                eprintln!("Parsing export file {}...", pathbuf.display());
+            }
+            let start = std::time::Instant::now();
             match OpenOptions::new().read(true).truncate(false).open(pathbuf) {
-                Ok(file) => crate::parser::parse_export_file(BufReader::new(file), self),
+                Ok(file) => {
+                    let result = crate::parser::parse_export_file(BufReader::new(file), self);
+                    if print_progress { log_parsed(start, &result); }
+                    result
+                },
                 Err(e) => Err(Box::from(format!("Failed to open export file: {:?}", e))),
             }
         } else if self.use_stdin {
+            if print_progress {
+                eprintln!("Parsing export file from stdin...");
+            }
+            let start = std::time::Instant::now();
             let reader = BufReader::new(std::io::stdin());
-            crate::parser::parse_export_file(reader, self)
+            let result = crate::parser::parse_export_file(reader, self);
+            if print_progress { log_parsed(start, &result); }
+            result
         } else {
             panic!("Configuration file must specify en export file path or \"use_stdin\": true")
         }


### PR DESCRIPTION
## Motivation

When checking large exports like mathlib (500k+ declarations), `nanoda_lib` runs silently for dozens of minutes with no feedback. Users cannot tell whether the checker is making progress, stuck, or how far along it is.

## What this adds

Opt-in progress reporting to stderr at each stage of the pipeline, controlled by two config options:

| Option | Type | Default | Description |
|--------|------|---------|-------------|
| `print_progress` | `bool` | `false` | Enable progress messages on stderr |
| `print_progress_step` | `usize` | `1000` | Report every N declarations during checking |

**Default behavior is unchanged** — progress reporting is entirely opt-in.

### Example config

```json
{
    "print_progress": true,
    "print_progress_step": 5000
}
```

### Example output (non-TTY, e.g. CI log)

```
Parsing export file Mathlib/export...
Parsed 538129 declarations in 4.8s
Checking 538129 declarations with 8 workers...
[5000/538129] Lean.Parser.Term.dynamicQuot
[10000/538129] Lean.Elab.Tactic.BVDecide.Frontend.instCommBVPred
[15000/538129] Mathlib.Order.BoundedOrder.instOrderBotProd
...
Checked all 538129 declarations in 127.3s
Pretty printing to stdout...
Total time: 132.5s
```

On a TTY, progress lines overwrite in-place (using `\r\x1b[K`) for cleaner output.

### Debugging stuck declarations

Each declaration name is logged *before* its check begins. There is no mechanism that tracks which declarations are currently in-flight across workers and reports them on completion — this keeps the implementation simple. The trade-off is that to identify a stuck or unexpectedly slow declaration, you need to run with serial checking (`num_threads` set to 1) and `print_progress_step` set to `1`. The last printed name is the one currently being checked.

## Implementation details

- **Config**: two new fields on `Config` (`print_progress`, `print_progress_step`), plus a computed `is_tty` field (via `std::io::IsTerminal`, not user-facing)
- **Name formatting**: added `format_name` / `format_name_prefix` helpers on `ExportFile` to render declaration names without allocating a full pretty-printer
- **Reporting call sites**: parsing (`to_export_file`), serial checking, parallel checking, and pretty printing phases all report when `print_progress` is true
- **Thread safety**: parallel checking uses `AtomicUsize` for the counter; progress lines may interleave slightly but remain correct

All output goes to **stderr** so it never interferes with stdout pretty-printer output or piped results.

## Files changed

- `src/util.rs` — `Config` fields, `format_name`, `print_progress` method, progress in `to_export_file`
- `src/tc.rs` — progress calls in `check_all_declars`, `check_all_declars_serial`, `check_all_declars_par`
- `src/main.rs` — total time reporting
- `src/pretty_printer.rs` — "Pretty printing..." message
- `README.md` — document `print_progress` and `print_progress_step` options