### PR TITLE
feat: Change exit code for incorrect backrefs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "nanoda_lib"
-version = "0.4.9-beta"
+version = "0.4.10-beta"
 dependencies = [
  "indexmap",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "nanoda_lib"
-version = "0.4.9-beta"
+version = "0.4.10-beta"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/ammkrn/nanoda_lib"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -85,22 +85,49 @@ enum BackRef {
 }
 
 impl BackRef {
-    fn assert_in(self, insert_result: (usize, bool)) {
-        assert!(insert_result.1);
-        let lhs = u32::try_from(insert_result.0).unwrap();
-        assert_eq!(self, BackRef::In(lhs))
+    fn assert_in(self, (idx, inserted): (usize, bool)) {
+        if !inserted {
+            panic!("Attempted to insert duplicate Name");
+        }
+        let lhs = u32::try_from(idx).unwrap();
+        if self != BackRef::In(lhs) {
+            eprintln!(
+                "Declined: Name back-reference mismatch, expected {:?}, found {:?}. Back-refs must be continuous.",
+                BackRef::In(lhs),
+                self
+            );
+            std::process::exit(2);
+        }
     }
 
-    fn assert_il(self, insert_result: (usize, bool)) {
-        assert!(insert_result.1);
-        let lhs = u32::try_from(insert_result.0).unwrap();
-        assert_eq!(self, BackRef::Il(lhs))
+    fn assert_il(self, (idx, inserted): (usize, bool)) {
+        if !inserted {
+            panic!("Attempted to insert duplicate Level");
+        }
+        let lhs = u32::try_from(idx).unwrap();
+        if self != BackRef::Il(lhs) {
+            eprintln!(
+                "Declined: Level back-reference mismatch, expected {:?}, found {:?}. Back-refs must be continuous.",
+                BackRef::Il(lhs),
+                self
+            );
+            std::process::exit(2);
+        }
     }
 
-    fn assert_ie(self, insert_result: (usize, bool)) {
-        assert!(insert_result.1);
-        let lhs = u32::try_from(insert_result.0).unwrap();
-        assert_eq!(self, BackRef::Ie(lhs))
+    fn assert_ie(self, (idx, inserted): (usize, bool)) {
+        if !inserted {
+            panic!("Attempted to insert duplicate Expr");
+        }
+        let lhs = u32::try_from(idx).unwrap();
+        if self != BackRef::Ie(lhs) {
+            eprintln!(
+                "Declined: Expr back-reference mismatch, expected {:?}, found {:?}. Back-refs must be continuous.",
+                BackRef::Ie(lhs),
+                self
+            );
+            std::process::exit(2);
+        }
     }
 }
 


### PR DESCRIPTION
Changes the behavior when encountering incorrect (discontiguous) backrefs from panic (exit code 101) to terminating with exit code 2. This is being used downstream as a signal that checking has been "declined" by a particular checker (e.g. for reasons having to do with implementation differences) rather than a signal that a particular environment or proof is not well typed.