### PR TITLE
fix: more struct and inductive checks

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -1,6 +1,7 @@
 use crate::util::{ExprPtr, FxHashMap, FxIndexMap, LevelsPtr, NamePtr};
 use std::sync::Arc;
 use serde::Deserialize;
+use std::collections::HashSet;
 
 /// Reducibility hints accompany definitions; used to determine how
 /// to unfold expressions in order to most efficiently proceed.
@@ -84,6 +85,20 @@ pub struct InductiveData<'a> {
     pub(crate) all_ctor_names: Arc<[NamePtr<'a>]>,
 }
 
+impl<'a> InductiveData<'a> {
+    pub fn aux_data_ck(&self, temp: &Self) -> bool {
+        self.info.name == temp.info.name &&
+        self.num_params == temp.num_params &&
+        self.num_indices == temp.num_indices &&
+        self.is_nested == temp.is_nested &&
+        (self.all_ctor_names.iter().collect::<HashSet<_>>() == temp.all_ctor_names.iter().collect::<HashSet<_>>()) &&
+        if temp.is_nested {
+            self.all_ind_names.iter().collect::<HashSet<_>>().is_subset(&temp.all_ind_names.iter().collect::<HashSet<_>>())
+        } else {
+            self.all_ind_names.iter().collect::<HashSet<_>>() == temp.all_ind_names.iter().collect::<HashSet<_>>()
+        }
+    }
+}
 /// `inductive_name` is the name of the type this constructs. e.g. `Prod` for `Prod.mk`
 ///
 /// `ctor_idx` is 0-based; e.g. `List.nil (ctor_idx := 0)`, `List.cons (ctor_idx := 1)`
@@ -109,6 +124,16 @@ pub struct ConstructorData<'a> {
     pub num_fields: u16,
 }
 
+impl<'a> ConstructorData<'a> {
+    pub fn aux_data_ck(&self, other: &Self) -> bool {
+        self.info.name == other.info.name &&
+        self.inductive_name == other.inductive_name &&
+        self.ctor_idx == other.ctor_idx &&
+        self.num_params == other.num_params &&
+        self.num_fields == other.num_fields
+    }
+}
+
 /// Information received from the export file regarding a recursor.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RecursorData<'a> {
@@ -126,6 +151,16 @@ impl<'a> RecursorData<'a> {
     /// Compute the index in the recursor's type (in the telescope) where the major premise is located. 
     pub fn major_idx(&self) -> usize {
         (self.num_params + self.num_motives + self.num_minors + self.num_indices) as usize
+    }
+    
+    pub fn aux_data_ck(&self, other: &Self) -> bool {
+        self.num_params == other.num_params &&
+        self.num_indices == other.num_indices &&
+        self.num_motives == other.num_motives &&
+        self.num_minors == other.num_minors &&
+        self.is_k == other.is_k &&
+        self.info.name == other.info.name &&
+        (self.all_inductives.iter().collect::<HashSet<_>>() == other.all_inductives.iter().collect::<HashSet<_>>())
     }
 }
 
@@ -270,6 +305,15 @@ impl<'x, 'a: 'x> Env<'x, 'a> {
             Some(InductiveData { is_recursive, num_indices, all_ctor_names, .. }) =>
                 (!is_recursive) && (all_ctor_names.len() == 1) && (*num_indices == 0),
             _ => false,
+        }
+    }
+
+    pub fn get_structure(&self, n: &NamePtr<'a>, rec_ok: bool) -> Option<&InductiveData<'a>> {
+        match self.get_inductive(n) {
+            Some(i @ InductiveData { is_recursive, num_indices, all_ctor_names, .. }) 
+                if (all_ctor_names.len() == 1) && (*num_indices == 0) && (rec_ok || !is_recursive)=> Some(i),
+            _ => None,
+
         }
     }
 

--- a/src/inductive.rs
+++ b/src/inductive.rs
@@ -8,6 +8,25 @@ impl<'t, 'p: 't> ExportFile<'p> {
     pub(crate) fn check_inductive_declar(&self, d: &Declar<'t>) {
         let (ind, env_limit) = match d {
             Declar::Inductive(ind) => {
+                // Assert computed `is_recursive` value matches the export file.
+                let is_recursive = self.with_ctx(|ctx| {
+                    for ctor_name in ind.all_ctor_names.iter() {
+                        match self.declars.get(ctor_name).unwrap() {
+                            Declar::Constructor(ctor_data @ ConstructorData {..}) => {
+                                let mut ctor_ty = ctor_data.info.ty;
+                                while let Pi {binder_type, body, ..} = ctx.read_expr(ctor_ty) {
+                                    if ctx.find_const(binder_type, |n| ind.all_ind_names.iter().any(|nn| n == *nn)) {
+                                        return true
+                                    }
+                                    ctor_ty = body;
+                                }
+                            },
+                            _ => panic!()
+                        }
+                    }
+                    false
+                });
+                assert_eq!(ind.is_recursive, is_recursive);
                 let (start, size) = self.mutual_block_sizes.get(&ind.info.name).unwrap();
                 (ind, crate::env::EnvLimit::ByIndex(start + size))
             }
@@ -1181,6 +1200,7 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
         for name in base_ind.all_ind_names.iter() {
             match (self.env.get_old_declar(name), self.env.get_temp_declar(name)) {
                 (Some(Declar::Inductive(old)), Some(Declar::Inductive(new))) => {
+                    assert!(old.aux_data_ck(new));
                     debug_assert!(!std::ptr::eq(old, new));
                     self.tc_cache.clear();
                     self.assert_def_eq(old.info.ty, new.info.ty);
@@ -1196,6 +1216,7 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
             for ctor in inductive.ctors.iter() {
                 match (self.env.get_old_declar(&ctor.name), self.env.get_temp_declar(&ctor.name)) {
                     (Some(Declar::Constructor(old)), Some(Declar::Constructor(new))) => {
+                        assert!(old.aux_data_ck(new));
                         debug_assert!(!std::ptr::eq(old, new));
                         self.tc_cache.clear();
                         self.assert_def_eq(old.info.ty, new.info.ty);
@@ -1229,10 +1250,11 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
         for new_rec in recursors {
             match (self.env.get_old_declar(&new_rec.info().name), new_rec) {
                 (
-                    Some(old @ Declar::Recursor(RecursorData { rec_rules: old_rec_rules, .. })),
-                    new @ Declar::Recursor(RecursorData { rec_rules: new_rec_rules, .. })
+                    Some(old @ Declar::Recursor(old_r @ RecursorData { rec_rules: old_rec_rules, .. })),
+                    new @ Declar::Recursor(new_r @ RecursorData { rec_rules: new_rec_rules, .. })
                 ) => {
                     self.tc_cache.clear();
+                    assert!(old_r.aux_data_ck(new_r));
                     assert!(!std::ptr::eq(old, new));
                     // Should be structurally != because they come from different envs.
                     assert_ne!(old, new);
@@ -1589,6 +1611,7 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
         let resolved_rec_name = nested_rec_name_to_rec_name.get(&rec_name).copied().unwrap_or(rec_name);
         match self.env.get_old_declar(&resolved_rec_name) {
             Some(Declar::Recursor(original @ RecursorData { .. })) => {
+                assert!(original.aux_data_ck(&restored));
                 self.tc_cache.clear();
                 self.assert_def_eq(original.info.ty, restored.info.ty);
                 // have to do the rec rules as well.
@@ -1639,6 +1662,7 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
         old_ctor: &ConstructorData<'t>,
     ) {
         let new_ctor @ ConstructorData { .. } = self.env.get_constructor(&old_ctor.info.name).unwrap();
+        assert!(old_ctor.aux_data_ck(&new_ctor));
         let new_ty = self.restore_e(st, new_ctor.info.ty, rec_name_map);
         self.tc_cache.clear();
         self.assert_def_eq(old_ctor.info.ty, new_ty);
@@ -1657,6 +1681,7 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
                 self.env.get_temp_declar(&unmodified_ind_type.name),
             ) {
                 (Some(Declar::Inductive(old)), Some(Declar::Inductive(new))) => {
+                    assert!(old.aux_data_ck(new));
                     debug_assert!(!std::ptr::eq(old, new));
                     self.tc_cache.clear();
                     self.assert_def_eq(old.info.ty, new.info.ty);

--- a/src/tc.rs
+++ b/src/tc.rs
@@ -215,7 +215,7 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
         // `c_name = Point`
         let (_f, c_name, c_levels, args) = self.ctx.unfold_const_apps(e_type)?;
         // `Point` declaration
-        let InductiveData { all_ctor_names, .. } = self.env.get_inductive(&c_name)?;
+        let InductiveData { all_ctor_names, .. } = self.env.get_structure(&c_name, false)?;
         // Name = `Point.mk`
         let ctor_name0 = all_ctor_names.get(0).copied()?;
         // Ctor data for `Point.mk`
@@ -324,10 +324,7 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
     fn def_eq_unit(&mut self, x: ExprPtr<'t>, y: ExprPtr<'t>) -> Option<bool> {
         let x_ty = self.infer_then_whnf(x, InferOnly);
         let (_, name, _levels, _) = self.ctx.unfold_const_apps(x_ty)?;
-        let InductiveData { num_indices, all_ctor_names, .. } = self.env.get_inductive(&name)?;
-        if all_ctor_names.len() != 1 || *num_indices != 0 {
-            return None
-        }
+        let InductiveData { all_ctor_names, .. } = self.env.get_structure(&name, false)?;
         let ctor_name = &all_ctor_names[0];
         let ctor = self.env.get_constructor(ctor_name)?;
         if ctor.num_fields != 0 {
@@ -440,7 +437,7 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
         let (_, struct_ty_name, struct_ty_levels, struct_ty_args) = self.ctx.unfold_const_apps(structure_ty).unwrap();
 
         let InductiveData { info: inductive_info, all_ctor_names, num_params, .. } =
-            self.env.get_inductive(&struct_ty_name).unwrap();
+            self.env.get_structure(&struct_ty_name, true).unwrap();
 
         let ConstructorData { info: ctor_info, .. } = self.env.get_constructor(&all_ctor_names[0]).unwrap();
         let mut ctor_ty = self.ctx.subst_declar_info_levels(*ctor_info, struct_ty_levels);


### PR DESCRIPTION
Fixes two things: (1) more strict/nuanced handling for structure/proj interactions, and (2) adds methods for enforcing that generated auxiliary data for inductives, constructors, and recursors are more strictly checked against the assertions in the export file.