### PR TITLE
fix: is_sort guards, disable union find eq

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "nanoda_lib"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "indexmap",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "nanoda_lib"
-version = "0.4.14"
+version = "0.4.15"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/ammkrn/nanoda_lib"

--- a/src/inductive.rs
+++ b/src/inductive.rs
@@ -5,11 +5,10 @@ use crate::util::{FxHashSet, ExportFile, ExprPtr, FxIndexMap, LevelPtr, LevelsPt
 use std::sync::Arc;
 
 impl<'t, 'p: 't> ExportFile<'p> {
-    pub(crate) fn check_inductive_declar(&self, d: &Declar<'t>) {
-        let (ind, env_limit) = match d {
+    pub(crate) fn is_recursive(&self, ind_name: &NamePtr<'t>) -> bool {
+        match self.declars.get(ind_name).unwrap() {
             Declar::Inductive(ind) => {
-                // Assert computed `is_recursive` value matches the export file.
-                let is_recursive = self.with_ctx(|ctx| {
+                self.with_ctx(|ctx| {
                     for ctor_name in ind.all_ctor_names.iter() {
                         match self.declars.get(ctor_name).unwrap() {
                             Declar::Constructor(ctor_data @ ConstructorData {..}) => {
@@ -25,8 +24,20 @@ impl<'t, 'p: 't> ExportFile<'p> {
                         }
                     }
                     false
-                });
-                assert_eq!(ind.is_recursive, is_recursive);
+                })
+
+            },
+            _ => panic!("Not an inductive declaration")
+        }
+    }
+
+    pub(crate) fn check_inductive_declar(&self, d: &Declar<'t>) {
+        let (ind, env_limit) = match d {
+            Declar::Inductive(ind) => {
+                // Assert computed `is_recursive` value matches the export file. Lean considers
+                // all types in a mutual block to be `is_rec: true` if any one of them is recursive.
+                let block_is_recursive = ind.all_ind_names.iter().any(|ind_name| self.is_recursive(ind_name));
+                assert_eq!(ind.is_recursive, block_is_recursive);
                 self.with_ctx(|ctx| {
                     let nested_pfx = ctx.str1("_nested");
                     assert!(!ctx.has_nested_pfx(ind.info.ty, nested_pfx));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@ pub mod quot;
 pub mod tc;
 #[cfg(test)]
 mod tests;
-pub mod union_find;
 pub mod unique_hasher;
 pub mod util;
 

--- a/src/tc.rs
+++ b/src/tc.rs
@@ -4,7 +4,7 @@ use crate::expr::Expr;
 use crate::util::{
     nat_div, nat_mod, nat_sub, nat_gcd, nat_land, nat_lor, 
     nat_xor, nat_shr, nat_shl, ExportFile, ExprPtr, LevelPtr, 
-    LevelsPtr, NamePtr, TcCache, TcCtx, StringPtr
+    LevelsPtr, NamePtr, TcCache, TcCtx, StringPtr, SortedPair
 };
 use std::error::Error;
 use num_traits::pow::Pow;
@@ -964,7 +964,7 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
             }
         };
         if result {
-            self.tc_cache.eq_cache.union(x, y);
+            self.tc_cache.eq_cache.insert(SortedPair::new(x, y));
         }
         result
     }
@@ -1139,7 +1139,7 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
         if x == y {
             return Some(true)
         }
-        if self.tc_cache.eq_cache.check_uf_eq(x, y) {
+        if self.tc_cache.eq_cache.contains(&SortedPair::new(x, y)) {
             return Some(true)
         }
         if let Some(r) = self.def_eq_sort(x, y) {
@@ -1152,13 +1152,11 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
     }
 
     fn failure_cache_contains(&self, x: ExprPtr<'t>, y: ExprPtr<'t>) -> bool {
-        let pr = if x.get_hash() <= y.get_hash() { (x, y) } else { (y, x) };
-        self.tc_cache.failure_cache.contains(&pr)
+        self.tc_cache.failure_cache.contains(&SortedPair::new(x, y))
     }
 
     fn failure_cache_insert(&mut self, x: ExprPtr<'t>, y: ExprPtr<'t>) {
-        let pr = if x.get_hash() <= y.get_hash() { (x, y) } else { (y, x) };
-        self.tc_cache.failure_cache.insert(pr);
+        self.tc_cache.failure_cache.insert(SortedPair::new(x, y));
     }
 
     fn try_eq_const_app(
@@ -1280,7 +1278,7 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
         let ty = self.infer_then_whnf(e, InferOnly);
         match self.ctx.read_expr(ty) {
             Sort { level, .. } => (self.ctx.is_zero(level), ty),
-            _ => (false, ty),
+            _ => panic!("expected a sort")
         }
     }
 
@@ -1288,7 +1286,7 @@ impl<'x, 't: 'x, 'p: 't> TypeChecker<'x, 't, 'p> {
         let ty = self.infer_then_whnf(e, InferOnly);
         match self.ctx.read_expr(ty) {
             Sort { level, .. } => (self.ctx.may_be_prop(level), ty),
-            _ => (false, ty),
+            _ => panic!("expected a sort")
         }
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,7 +4,6 @@ use crate::level::Level;
 use crate::name::Name;
 use crate::pretty_printer::{PpOptions, PrettyPrinter};
 use crate::tc::TypeChecker;
-use crate::union_find::UnionFind;
 use crate::unique_hasher::UniqueHasher;
 use indexmap::{IndexMap, IndexSet};
 use num_bigint::BigUint;
@@ -816,14 +815,27 @@ pub struct NameCache<'p> {
     pub(crate) list_cons: Option<NamePtr<'p>>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SortedPair<'t>(ExprPtr<'t>, ExprPtr<'t>);
+
+impl<'t> SortedPair<'t> {
+    pub fn new(a: ExprPtr<'t>, b: ExprPtr<'t>) -> Self {
+        if a.get_hash() <= b.get_hash() {
+            Self(a, b)
+        } else {
+            Self(b, a)
+        }
+    }
+}
+
 pub(crate) struct TcCache<'t> {
     pub(crate) infer_cache_check: UniqueHashMap<ExprPtr<'t>, ExprPtr<'t>>,
     pub(crate) infer_cache_no_check: UniqueHashMap<ExprPtr<'t>, ExprPtr<'t>>,
     pub(crate) whnf_cache: UniqueHashMap<ExprPtr<'t>, ExprPtr<'t>>,
     pub(crate) whnf_no_unfolding_cache: UniqueHashMap<ExprPtr<'t>, ExprPtr<'t>>,
-    pub(crate) eq_cache: UnionFind<ExprPtr<'t>>,
+    pub(crate) eq_cache: FxHashSet<SortedPair<'t>>,
     /// A cache of congruence failures during the lazy delta step procedure.
-    pub(crate) failure_cache: FxHashSet<(ExprPtr<'t>, ExprPtr<'t>)>,
+    pub(crate) failure_cache: FxHashSet<SortedPair<'t>>,
     /// Strong reduction is not used during type-checking, this is more of a library/inspection feature.
     pub(crate) strong_cache: UniqueHashMap<(ExprPtr<'t>, bool, bool), ExprPtr<'t>>,
 }
@@ -835,7 +847,7 @@ impl<'t> TcCache<'t> {
             infer_cache_no_check: new_unique_hash_map(),
             whnf_cache: new_unique_hash_map(),
             whnf_no_unfolding_cache: new_unique_hash_map(),
-            eq_cache: UnionFind::new(),
+            eq_cache: new_fx_hash_set(),
             failure_cache: new_fx_hash_set(),
             strong_cache: new_unique_hash_map(),
         }


### PR DESCRIPTION
is_sort must panic if the expression argument does not normalize to a Sort.

disables the union find equality cache in favor of sorted pairs which do not try to exploit transitivity.

make the `is_recursive` check respect the whole mutual block's is_recursive flag. In a mutual block with one recursive type and one non-recursive type, all types in the block are tagged as recursive in the export file.